### PR TITLE
security: Fix CodeQL alerts - string escaping and workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+# Explicitly set minimal permissions (security best practice)
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test Python ${{ matrix.python-version }}

--- a/npm/src/index.ts
+++ b/npm/src/index.ts
@@ -253,7 +253,7 @@ from qwed_legal import CitationGuard
 import json
 
 guard = CitationGuard()
-result = guard.verify("${citation.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}")
+result = guard.verify("${escapePythonString(citation)}")
 
 print(json.dumps({
     "valid": result.valid,

--- a/npm/src/index.ts
+++ b/npm/src/index.ts
@@ -78,10 +78,15 @@ export interface StatuteResult {
 
 /**
  * Escape a string for safe interpolation into Python string literals.
- * Escapes backslashes first, then quotes, to prevent injection attacks.
+ * Escapes backslashes first, then quotes, then control characters.
+ * This prevents injection attacks via quotes, backslashes, or newlines.
  */
 function escapePythonString(str: string): string {
-    return str.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+    return str
+        .replace(/\\/g, '\\\\')
+        .replace(/"/g, '\\"')
+        .replace(/\n/g, '\\n')
+        .replace(/\r/g, '\\r');
 }
 
 // ============================================================================

--- a/npm/src/index.ts
+++ b/npm/src/index.ts
@@ -241,7 +241,7 @@ from qwed_legal import CitationGuard
 import json
 
 guard = CitationGuard()
-result = guard.verify("${citation.replace(/"/g, '\\"')}")
+result = guard.verify("${citation.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}")
 
 print(json.dumps({
     "valid": result.valid,

--- a/npm/src/index.ts
+++ b/npm/src/index.ts
@@ -73,6 +73,18 @@ export interface StatuteResult {
 }
 
 // ============================================================================
+// Security Helper
+// ============================================================================
+
+/**
+ * Escape a string for safe interpolation into Python string literals.
+ * Escapes backslashes first, then quotes, to prevent injection attacks.
+ */
+function escapePythonString(str: string): string {
+    return str.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+// ============================================================================
 // Base Runner
 // ============================================================================
 
@@ -124,8 +136,8 @@ export class DeadlineVerifier {
 from qwed_legal import DeadlineGuard
 import json
 
-guard = DeadlineGuard(country="${country}")
-result = guard.verify("${signingDate}", "${term}", "${claimedDeadline}")
+guard = DeadlineGuard(country="${escapePythonString(country)}")
+result = guard.verify("${escapePythonString(signingDate)}", "${escapePythonString(term)}", "${escapePythonString(claimedDeadline)}")
 
 print(json.dumps({
     "verified": result.verified,
@@ -278,13 +290,13 @@ export class JurisdictionVerifier {
         forum?: string
     ): Promise<JurisdictionResult> {
         const partiesJson = JSON.stringify(partiesCountries);
-        const forumArg = forum ? `"${forum}"` : 'None';
+        const forumArg = forum ? `"${escapePythonString(forum)}"` : 'None';
         const script = `
 from qwed_legal import JurisdictionGuard
 import json
 
 guard = JurisdictionGuard()
-result = guard.verify_choice_of_law(${partiesJson}, "${governingLaw}", ${forumArg})
+result = guard.verify_choice_of_law(${partiesJson}, "${escapePythonString(governingLaw)}", ${forumArg})
 
 print(json.dumps({
     "verified": result.verified,
@@ -311,7 +323,7 @@ from qwed_legal import JurisdictionGuard
 import json
 
 guard = JurisdictionGuard()
-result = guard.check_convention_applicability(${partiesJson}, "${convention}")
+result = guard.check_convention_applicability(${partiesJson}, "${escapePythonString(convention)}")
 
 print(json.dumps({
     "verified": result.verified,
@@ -352,7 +364,7 @@ from qwed_legal import StatuteOfLimitationsGuard
 import json
 
 guard = StatuteOfLimitationsGuard()
-result = guard.verify("${claimType}", "${jurisdiction}", "${incidentDate}", "${filingDate}")
+result = guard.verify("${escapePythonString(claimType)}", "${escapePythonString(jurisdiction)}", "${escapePythonString(incidentDate)}", "${escapePythonString(filingDate)}")
 
 print(json.dumps({
     "verified": result.verified,
@@ -381,7 +393,7 @@ from qwed_legal import StatuteOfLimitationsGuard
 import json
 
 guard = StatuteOfLimitationsGuard()
-period = guard.get_limitation_period("${claimType}", "${jurisdiction}")
+period = guard.get_limitation_period("${escapePythonString(claimType)}", "${escapePythonString(jurisdiction)}")
 
 print(json.dumps(period))
 `;


### PR DESCRIPTION
## Summary
QWED ecosystem consistency + security hardening.

## Changes

### Ecosystem Consistency
- Add "100% Deterministic" badge variant
- Add determinism guarantee docs link
- Add `verification_mode` field to `DeadlineResult`

### Security Fixes (CodeQL)
- **CWE-116:** Fix incomplete string escaping in npm SDK
  - Now escapes backslashes before quotes to prevent injection
- **Workflow Permissions:** Add explicit `contents: read` permission

## Testing
- All existing tests pass
- CodeQL alerts should resolve after merge

## References
- OWASP A1: Injection
- CWE-116, CWE-20
- GitHub Security: Workflow Permissions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Verification now escapes special characters in citations, dates, jurisdictions and other fields to prevent injection and parsing errors, improving validation reliability.

* **Chores**
  * CI workflow permissions tightened to minimal read-only access for repository contents, enhancing security without altering job behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->