### PR TITLE
fix: export IRACGuard, FairnessGuard, ContradictionGuard, SACProcessor + README fixes (v0.3.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,21 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
       
-      - name: Run tests
-        run: pytest tests/ -v --tb=short
+      - name: Run tests with coverage
+        run: pytest tests/ -v --tb=short --cov=qwed_legal --cov-report=xml
+      
+      - name: Upload coverage to Codecov
+        if: matrix.python-version == '3.12'
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: QWED-AI/qwed-legal
+          files: coverage.xml
+          fail_ci_if_error: false
       
       - name: Check code style (Python 3.11 only)
         if: matrix.python-version == '3.11'
         run: |
           pip install ruff
           ruff check .
+

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@
 | **Accuracy** | ~95% (hallucination risk) | 100% mathematical certainty |
 | **Tech** | GPT-4, Claude, custom LLMs | SymPy + Z3 SMT Solver |
 | **Model** | Closed SaaS platform | Open-source SDK |
-| **Pricing** | $1000s/month enterprise | Free (MIT License) |
+| **Pricing** | $1000s/month enterprise | Free (Apache 2.0 License) |
 
 ### Use Together (Best Practice)
 ```
@@ -148,7 +148,7 @@ print(result["message"])
 
 ---
 
-## 🛡️ The Seven Guards
+## 🛡️ The Nine Guards
 
 | Guard | What It Verifies |
 |-------|------------------|
@@ -158,7 +158,9 @@ print(result["message"])
 | **CitationGuard** | Legal citations (Bluebook format, case names, reporters) |
 | **JurisdictionGuard** | Choice of law, forum selection, cross-border conflicts |
 | **StatuteOfLimitationsGuard** | Claim periods by jurisdiction and claim type |
-| **FairnessGuard** | Counterfactual tests for bias (Requires `llm_client`) |
+| **IRACGuard** | Legal reasoning structure (Issue→Rule→Application→Conclusion) |
+| **ContradictionGuard** | Z3-powered logical contradiction detection between clauses |
+| **FairnessGuard** | Counterfactual bias testing (Requires `llm_client`) |
 
 ### Verify Legal Citations
 
@@ -531,12 +533,15 @@ Typically <10ms per verification. The symbolic math engine is highly optimized.
 
 ## 🗺️ Roadmap
 
-### ✅ Released (v0.2.0)
+### ✅ Released (v0.3.0)
 - [x] DeadlineGuard with business day calculations
 - [x] LiabilityGuard for cap verification
 - [x] ClauseGuard for contradiction detection
-- **Reasoning Verification**: `IRACGuard` ensures legal reasoning follows Issue-Rule-Application-Conclusion structure.
-- **Authority Verification**: `CitationGuard` (v0.2.0) checks for hallucinated case citations.
+- [x] **IRACGuard** — Ensures legal reasoning follows Issue-Rule-Application-Conclusion structure
+- [x] **ContradictionGuard** — Z3-powered logical contradiction detection between clauses
+- [x] **FairnessGuard** — Counterfactual bias testing for judicial fairness
+- [x] **CitationGuard** — Checks for hallucinated case citations (Bluebook format)
+- [x] **SACProcessor** — Summary-Augmented Chunking for DRM prevention in legal RAG
 
 ## 🌍 Global Jurisdiction Support (v0.2.0)
 QWED-Legal now supports cross-border verification:
@@ -544,7 +549,6 @@ QWED-Legal now supports cross-border verification:
 *   **StatuteOfLimitationsGuard:** Deterministically calculates filing deadlines for CA, NY, TX, UK, and more.
 *   **Attestation:** Every verification can be cryptographically signed (JWT) to provide an audit trail of safety checks.
 
-## 📦 Installation
 - [x] JurisdictionGuard for choice of law verification
 - [x] StatuteOfLimitationsGuard for claim periods
 - [x] TypeScript/npm SDK (@qwed-ai/legal)
@@ -569,6 +573,7 @@ QWED-Legal now supports cross-border verification:
 |---------|---------|
 | [qwed-verification](https://github.com/QWED-AI/qwed-verification) | Core verification engine |
 | [qwed-finance](https://github.com/QWED-AI/qwed-finance) | Banking & financial verification |
+| [qwed-tax](https://github.com/QWED-AI/qwed-tax) | Tax calculation verification |
 | [qwed-ucp](https://github.com/QWED-AI/qwed-ucp) | E-commerce transaction verification |
 | [qwed-mcp](https://github.com/QWED-AI/qwed-mcp) | Claude Desktop integration |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "qwed-legal"
-version = "0.2.0"
+version = "0.3.0"
 description = "🏛️ Verification guards for legal contracts - Date calculations, clause consistency, liability verification"
 readme = "README.md"
 license = "Apache-2.0"

--- a/qwed_legal/__init__.py
+++ b/qwed_legal/__init__.py
@@ -102,7 +102,7 @@ class LegalGuard:
         """
         return self.contradiction.verify_consistency(clauses)
 
-    def verify_fairness(self, original_prompt: str, original_decision: str, protected_attribute_swap: dict):
+    def verify_fairness(self, original_prompt: str, original_decision: str, protected_attribute_swap: dict[str, str]):
         """Test for algorithmic bias using counterfactual testing.
 
         Requires ``llm_client`` to be provided at init time.

--- a/qwed_legal/__init__.py
+++ b/qwed_legal/__init__.py
@@ -11,15 +11,24 @@ from qwed_legal.guards.clause_guard import ClauseGuard
 from qwed_legal.guards.citation_guard import CitationGuard
 from qwed_legal.guards.jurisdiction_guard import JurisdictionGuard
 from qwed_legal.guards.statute_guard import StatuteOfLimitationsGuard
+from qwed_legal.guards.irac_guard import IRACGuard
+from qwed_legal.guards.fairness_guard import FairnessGuard
+from qwed_legal.guards.contradiction_guard import ContradictionGuard, Clause
+from qwed_legal.rag.sac_processor import SACProcessor
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 __all__ = [
     "DeadlineGuard",
-    "LiabilityGuard", 
+    "LiabilityGuard",
     "ClauseGuard",
     "CitationGuard",
     "JurisdictionGuard",
     "StatuteOfLimitationsGuard",
+    "IRACGuard",
+    "FairnessGuard",
+    "ContradictionGuard",
+    "Clause",
+    "SACProcessor",
     "LegalGuard",
 ]
 
@@ -27,15 +36,15 @@ __all__ = [
 class LegalGuard:
     """
     All-in-one legal verification guard.
-    
+
     Combines all guards for comprehensive contract verification.
-    
+
     Example:
         >>> from qwed_legal import LegalGuard
         >>> guard = LegalGuard()
         >>> result = guard.verify_deadline("2026-01-15", "30 business days", "2026-02-14")
     """
-    
+
     def __init__(self):
         self.deadline = DeadlineGuard()
         self.liability = LiabilityGuard()
@@ -43,28 +52,38 @@ class LegalGuard:
         self.citation = CitationGuard()
         self.jurisdiction = JurisdictionGuard()
         self.statute = StatuteOfLimitationsGuard()
-    
+        self.irac = IRACGuard()
+        self.contradiction = ContradictionGuard()
+
     def verify_deadline(self, signing_date: str, term: str, claimed_deadline: str):
         """Verify a deadline calculation."""
         return self.deadline.verify(signing_date, term, claimed_deadline)
-    
+
     def verify_liability_cap(self, contract_value: float, cap_percentage: float, claimed_cap: float):
         """Verify a liability cap calculation."""
         return self.liability.verify_cap(contract_value, cap_percentage, claimed_cap)
-    
+
     def check_clause_consistency(self, clauses: list[str]):
         """Check clauses for logical contradictions."""
         return self.clause.check_consistency(clauses)
-    
+
     def verify_citation(self, citation: str):
         """Verify a legal citation."""
         return self.citation.verify(citation)
-    
+
     def verify_jurisdiction(self, parties_countries: list[str], governing_law: str, forum: str = None):
         """Verify choice of law and forum selection."""
         return self.jurisdiction.verify_choice_of_law(parties_countries, governing_law, forum)
-    
+
     def verify_statute_of_limitations(self, claim_type: str, jurisdiction: str, incident_date: str, filing_date: str):
         """Verify if claim is within statute of limitations."""
         return self.statute.verify(claim_type, jurisdiction, incident_date, filing_date)
+
+    def verify_irac_structure(self, llm_output: str):
+        """Verify that legal reasoning follows IRAC structure."""
+        return self.irac.verify_structure(llm_output)
+
+    def verify_contradiction(self, clauses: list):
+        """Check clauses for logical contradictions using Z3."""
+        return self.contradiction.verify_consistency(clauses)
 

--- a/qwed_legal/__init__.py
+++ b/qwed_legal/__init__.py
@@ -39,13 +39,18 @@ class LegalGuard:
 
     Combines all guards for comprehensive contract verification.
 
+    Args:
+        llm_client: Optional LLM client for FairnessGuard counterfactual testing.
+            If not provided, ``verify_fairness()`` will raise ``ValueError``.
+            All other guards are fully deterministic and require no external client.
+
     Example:
         >>> from qwed_legal import LegalGuard
         >>> guard = LegalGuard()
         >>> result = guard.verify_deadline("2026-01-15", "30 business days", "2026-02-14")
     """
 
-    def __init__(self):
+    def __init__(self, llm_client=None):
         self.deadline = DeadlineGuard()
         self.liability = LiabilityGuard()
         self.clause = ClauseGuard()
@@ -54,6 +59,7 @@ class LegalGuard:
         self.statute = StatuteOfLimitationsGuard()
         self.irac = IRACGuard()
         self.contradiction = ContradictionGuard()
+        self.fairness = FairnessGuard(llm_client=llm_client)
 
     def verify_deadline(self, signing_date: str, term: str, claimed_deadline: str):
         """Verify a deadline calculation."""
@@ -64,7 +70,11 @@ class LegalGuard:
         return self.liability.verify_cap(contract_value, cap_percentage, claimed_cap)
 
     def check_clause_consistency(self, clauses: list[str]):
-        """Check clauses for logical contradictions."""
+        """Check clauses for contradictions using text-based heuristics (ClauseGuard).
+
+        Accepts raw clause strings. For Z3-powered formal logic verification
+        with structured ``Clause`` dataclass instances, use ``verify_contradiction()``.
+        """
         return self.clause.check_consistency(clauses)
 
     def verify_citation(self, citation: str):
@@ -83,7 +93,19 @@ class LegalGuard:
         """Verify that legal reasoning follows IRAC structure."""
         return self.irac.verify_structure(llm_output)
 
-    def verify_contradiction(self, clauses: list):
-        """Check clauses for logical contradictions using Z3."""
+    def verify_contradiction(self, clauses: list[Clause]):
+        """Check clauses for logical contradictions using Z3 SMT Solver (ContradictionGuard).
+
+        Accepts structured ``Clause`` dataclass instances with ``id``, ``text``,
+        ``category``, and ``value`` fields. For simple text-based contradiction
+        detection, use ``check_clause_consistency()``.
+        """
         return self.contradiction.verify_consistency(clauses)
+
+    def verify_fairness(self, original_prompt: str, original_decision: str, protected_attribute_swap: dict):
+        """Test for algorithmic bias using counterfactual testing.
+
+        Requires ``llm_client`` to be provided at init time.
+        """
+        return self.fairness.verify_decision_fairness(original_prompt, original_decision, protected_attribute_swap)
 

--- a/qwed_legal/guards/__init__.py
+++ b/qwed_legal/guards/__init__.py
@@ -6,6 +6,9 @@ from qwed_legal.guards.clause_guard import ClauseGuard
 from qwed_legal.guards.citation_guard import CitationGuard
 from qwed_legal.guards.jurisdiction_guard import JurisdictionGuard
 from qwed_legal.guards.statute_guard import StatuteOfLimitationsGuard
+from qwed_legal.guards.irac_guard import IRACGuard
+from qwed_legal.guards.fairness_guard import FairnessGuard
+from qwed_legal.guards.contradiction_guard import ContradictionGuard, Clause
 
 __all__ = [
     "DeadlineGuard",
@@ -14,5 +17,9 @@ __all__ = [
     "CitationGuard",
     "JurisdictionGuard",
     "StatuteOfLimitationsGuard",
+    "IRACGuard",
+    "FairnessGuard",
+    "ContradictionGuard",
+    "Clause",
 ]
 

--- a/qwed_legal/guards/fairness_guard.py
+++ b/qwed_legal/guards/fairness_guard.py
@@ -17,6 +17,9 @@ class FairnessGuard:
         if not self.llm_client:
             raise ValueError("LLM client must be provided for counterfactual execution.")
 
+        if not protected_attribute_swap:
+            return {"verified": True, "status": "NO_SWAP_REQUIRED", "message": "No protected attributes to swap."}
+
         # 1. Generate Counterfactual Prompt (single-pass to avoid cascade re-substitution)
         combined_pattern = r'\b(' + '|'.join(re.escape(k) for k in protected_attribute_swap) + r')\b'
         lower_swap_dict = {k.lower(): v for k, v in protected_attribute_swap.items()}


### PR DESCRIPTION
## Summary

Fixes 3 dead-code guards that existed in source but were never exported, making them importable for users. Also fixes multiple README inconsistencies.

## Changes

### Code Fixes
- **Export [IRACGuard](cci:2://file:///C:/Users/rahul/.gemini/antigravity/playground/vector-meteoroid/qwed-legal/qwed_legal/guards/irac_guard.py:3:0-57:9)** — IRAC reasoning structure verification (was dead code in [irac_guard.py](cci:7://file:///C:/Users/rahul/.gemini/antigravity/playground/vector-meteoroid/qwed-legal/qwed_legal/guards/irac_guard.py:0:0-0:0))
- **Export [FairnessGuard](cci:2://file:///C:/Users/rahul/.gemini/antigravity/playground/vector-meteoroid/qwed-legal/qwed_legal/guards/fairness_guard.py:3:0-55:64)** — Counterfactual bias testing (was dead code in [fairness_guard.py](cci:7://file:///C:/Users/rahul/.gemini/antigravity/playground/vector-meteoroid/qwed-legal/tests/test_fairness_guard.py:0:0-0:0))
- **Export [ContradictionGuard](cci:2://file:///C:/Users/rahul/.gemini/antigravity/playground/vector-meteoroid/qwed-legal/qwed_legal/guards/contradiction_guard.py:11:0-75:13) + [Clause](cci:2://file:///C:/Users/rahul/.gemini/antigravity/playground/vector-meteoroid/qwed-legal/qwed_legal/guards/contradiction_guard.py:4:0-9:59)** — Z3-powered logical contradiction detection (was dead code in [contradiction_guard.py](cci:7://file:///C:/Users/rahul/.gemini/antigravity/playground/vector-meteoroid/qwed-legal/qwed_legal/guards/contradiction_guard.py:0:0-0:0))
- **Export [SACProcessor](cci:2://file:///C:/Users/rahul/.gemini/antigravity/playground/vector-meteoroid/qwed-legal/qwed_legal/rag/sac_processor.py:26:0-162:70)** — Summary-Augmented Chunking for DRM prevention in legal RAG (was hidden in `rag/`)
- **Updated [LegalGuard](cci:2://file:///C:/Users/rahul/.gemini/antigravity/playground/vector-meteoroid/qwed-legal/qwed_legal/__init__.py:35:0-87:61)** wrapper with [verify_irac_structure()](cci:1://file:///C:/Users/rahul/.gemini/antigravity/playground/vector-meteoroid/qwed_new/src/qwed_new/guards/process_guard.py:20:4-49:9) and [verify_contradiction()](cci:1://file:///C:/Users/rahul/.gemini/antigravity/playground/vector-meteoroid/qwed-legal/qwed_legal/__init__.py:85:4-87:61) methods

### README Fixes
- Fixed license: said "MIT" → corrected to "Apache 2.0"
- Fixed guard count: "7 Guards" → "9 Guards"
- Removed duplicate "📦 Installation" header in roadmap section
- Added `qwed-tax` to related packages table
- Updated roadmap to v0.3.0 with all released guards listed

### Version Bump
- `0.2.0` → `0.3.0` in [pyproject.toml](cci:7://file:///C:/Users/rahul/.gemini/antigravity/playground/vector-meteoroid/qwed-legal/pyproject.toml:0:0-0:0) and [__init__.py](cci:7://file:///C:/Users/rahul/.gemini/antigravity/playground/vector-meteoroid/qwed-legal/tests/__init__.py:0:0-0:0)

## Tests
All existing tests pass ✅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added IRACGuard, ContradictionGuard, and FairnessGuard.
  * Added SACProcessor for document processing.
  * New verification capabilities: IRAC structure checks, contradiction detection, and fairness verification.

* **Documentation**
  * Updated README: guard roster and descriptions, roadmap bumped to v0.3.0.

* **Chores**
  * Version bumped to v0.3.0.
  * License updated to Apache 2.0.

* **Related Packages**
  * Added qwed-tax to related packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->