### PR TITLE
fix: fail closed ClauseGuard Z3 verification surface

### DIFF
--- a/qwed_legal/guards/clause_guard.py
+++ b/qwed_legal/guards/clause_guard.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 import re
 from typing import Any, List, Optional, Tuple
 
-from z3 import ExprRef, Solver, sat, unknown, unsat
+from z3 import BoolRef, Solver, sat, unknown, unsat
 
 
 @dataclass
@@ -40,8 +40,7 @@ class ClauseGuard:
     """
 
     def __init__(self):
-        """Initialize ClauseGuard with Z3 solver."""
-        self.solver = Solver()
+        """Initialize ClauseGuard."""
 
     def check_consistency(self, clauses: List[str]) -> ClauseResult:
         """
@@ -259,7 +258,7 @@ class ClauseGuard:
         invalid_positions = [
             index + 1
             for index, constraint in enumerate(constraints)
-            if not isinstance(constraint, ExprRef)
+            if not isinstance(constraint, BoolRef)
         ]
         if invalid_positions:
             positions = ", ".join(str(position) for position in invalid_positions)
@@ -268,7 +267,8 @@ class ClauseGuard:
                 conflicts=[],
                 message=(
                     "UNVERIFIABLE: verify_using_z3 only accepts explicit Z3 "
-                    f"expressions. Unsupported constraint(s) at position(s): {positions}."
+                    "Boolean expressions. Unsupported constraint(s) at "
+                    f"position(s): {positions}."
                 ),
             )
 
@@ -288,8 +288,8 @@ class ClauseGuard:
                 consistent=False,
                 conflicts=[],
                 message=(
-                    "ERROR: Provided Z3 constraints are unsatisfiable "
-                    "(contradiction exists)."
+                    "CONTRADICTION: Provided Z3 constraints are "
+                    "unsatisfiable (contradiction exists)."
                 ),
             )
 

--- a/qwed_legal/guards/clause_guard.py
+++ b/qwed_legal/guards/clause_guard.py
@@ -64,7 +64,7 @@ class ClauseGuard:
         propositions = self._extract_propositions(clauses)
 
         # Check for conflicts using supported heuristics
-        conflicts = self._find_conflicts(clauses, propositions)
+        conflicts = self._find_conflicts(propositions)
 
         if not conflicts:
             return ClauseResult(
@@ -111,7 +111,7 @@ class ClauseGuard:
         return propositions
 
     def _find_conflicts(
-        self, clauses: List[str], propositions: List[dict]
+        self, propositions: List[dict]
     ) -> List[Tuple[int, int, str]]:
         """Find logical conflicts between clauses."""
         conflicts = []

--- a/qwed_legal/guards/clause_guard.py
+++ b/qwed_legal/guards/clause_guard.py
@@ -1,19 +1,21 @@
 """
-ClauseGuard: Detect contradictory clauses in contracts using Z3 SMT solver.
+ClauseGuard: Detect contradictory clauses in contracts using limited heuristics.
 
-Uses formal logic to prove or disprove clause consistency.
+Supports optional typed Z3 constraints for power users who model legal meaning
+explicitly outside this guard.
 """
 
 from dataclasses import dataclass
-from typing import List, Optional, Tuple
 import re
+from typing import Any, List, Optional, Tuple
 
-from z3 import Solver, Bool, sat, unsat
+from z3 import ExprRef, Solver, sat, unknown, unsat
 
 
 @dataclass
 class ClauseResult:
     """Result of clause consistency check."""
+
     consistent: bool
     conflicts: List[Tuple[int, int, str]]  # (clause_idx1, clause_idx2, reason)
     message: str
@@ -21,13 +23,13 @@ class ClauseResult:
 
 class ClauseGuard:
     """
-    Detect contradictory clauses in legal contracts using Z3 SMT solver.
-    
-    Catches common LLM errors like:
+    Detect contradictory clauses in legal contracts using limited heuristics.
+
+    Catches some common LLM errors like:
     - Contradictory termination clauses
     - Conflicting obligation timelines
     - Mutually exclusive conditions
-    
+
     Example:
         >>> guard = ClauseGuard()
         >>> result = guard.check_consistency([
@@ -36,18 +38,18 @@ class ClauseGuard:
         ... ])
         >>> print(result.consistent)  # False - clauses conflict
     """
-    
+
     def __init__(self):
         """Initialize ClauseGuard with Z3 solver."""
         self.solver = Solver()
-    
+
     def check_consistency(self, clauses: List[str]) -> ClauseResult:
         """
         Check if a list of contract clauses are logically consistent.
-        
+
         Args:
             clauses: List of clause text strings
-        
+
         Returns:
             ClauseResult with consistency status and any detected conflicts
         """
@@ -55,42 +57,41 @@ class ClauseGuard:
             return ClauseResult(
                 consistent=True,
                 conflicts=[],
-                message="✅ Single clause - no conflicts possible."
+                message="Single clause - no conflicts possible.",
             )
-        
+
         # Extract logical propositions from clauses
         propositions = self._extract_propositions(clauses)
-        
-        # Check for conflicts using Z3
+
+        # Check for conflicts using supported heuristics
         conflicts = self._find_conflicts(clauses, propositions)
-        
+
         if not conflicts:
             return ClauseResult(
                 consistent=True,
                 conflicts=[],
-                message="✅ VERIFIED: All clauses are logically consistent."
+                message="VERIFIED: All supported clause checks found no conflicts.",
             )
-        
-        # Format conflict message
+
         conflict_msgs = []
         for idx1, idx2, reason in conflicts:
             conflict_msgs.append(
                 f"  - Clause {idx1 + 1} vs Clause {idx2 + 1}: {reason}"
             )
-        
+
         return ClauseResult(
             consistent=False,
             conflicts=conflicts,
             message=(
-                f"⚠️ WARNING: {len(conflicts)} potential conflict(s) detected:\n"
+                f"WARNING: {len(conflicts)} potential conflict(s) detected:\n"
                 + "\n".join(conflict_msgs)
-            )
+            ),
         )
-    
+
     def _extract_propositions(self, clauses: List[str]) -> List[dict]:
-        """Extract logical propositions from clause text."""
+        """Extract supported heuristic propositions from clause text."""
         propositions = []
-        
+
         for clause in clauses:
             lower = clause.lower()
             prop = {
@@ -99,49 +100,47 @@ class ClauseGuard:
                 "termination_notice_days": self._extract_days(lower, "notice"),
                 "min_term_days": self._extract_days(lower, "before"),
                 "is_exclusive": "exclusive" in lower or "only" in lower,
-                "is_prohibition": any(w in lower for w in ["may not", "cannot", "neither", "shall not"]),
+                "is_prohibition": any(
+                    w in lower for w in ["may not", "cannot", "neither", "shall not"]
+                ),
                 "is_permission": any(w in lower for w in ["may ", "can ", "allowed"]),
                 "parties": self._extract_parties(lower),
             }
             propositions.append(prop)
-        
+
         return propositions
-    
+
     def _find_conflicts(
-        self,
-        clauses: List[str],
-        propositions: List[dict]
+        self, clauses: List[str], propositions: List[dict]
     ) -> List[Tuple[int, int, str]]:
         """Find logical conflicts between clauses."""
         conflicts = []
-        
+
         for i, prop1 in enumerate(propositions):
             for j, prop2 in enumerate(propositions):
                 if j <= i:
                     continue
-                
-                # Check termination conflicts
+
                 conflict = self._check_termination_conflict(prop1, prop2)
                 if conflict:
                     conflicts.append((i, j, conflict))
                     continue
-                
-                # Check permission vs prohibition conflicts
+
                 conflict = self._check_permission_prohibition_conflict(prop1, prop2)
                 if conflict:
                     conflicts.append((i, j, conflict))
                     continue
-                
-                # Check exclusivity conflicts
+
                 conflict = self._check_exclusivity_conflict(prop1, prop2)
                 if conflict:
                     conflicts.append((i, j, conflict))
-        
+
         return conflicts
-    
-    def _check_termination_conflict(self, prop1: dict, prop2: dict) -> Optional[str]:
+
+    def _check_termination_conflict(
+        self, prop1: dict, prop2: dict
+    ) -> Optional[str]:
         """Check for conflicting termination clauses."""
-        # Permission to terminate vs minimum term
         if prop1.get("can_terminate") and prop2.get("min_term_days"):
             notice = prop1.get("termination_notice_days", 0)
             min_term = prop2.get("min_term_days", 0)
@@ -150,7 +149,7 @@ class ClauseGuard:
                     f"Termination notice ({notice} days) conflicts with "
                     f"minimum term ({min_term} days)"
                 )
-        
+
         if prop2.get("can_terminate") and prop1.get("min_term_days"):
             notice = prop2.get("termination_notice_days", 0)
             min_term = prop1.get("min_term_days", 0)
@@ -159,103 +158,150 @@ class ClauseGuard:
                     f"Termination notice ({notice} days) conflicts with "
                     f"minimum term ({min_term} days)"
                 )
-        
+
         return None
-    
-    def _check_permission_prohibition_conflict(self, prop1: dict, prop2: dict) -> Optional[str]:
+
+    def _check_permission_prohibition_conflict(
+        self, prop1: dict, prop2: dict
+    ) -> Optional[str]:
         """Check for permission vs prohibition conflicts."""
         if prop1.get("is_permission") and prop2.get("is_prohibition"):
-            # Check if they're about the same action
             if prop1.get("can_terminate") and "terminate" in prop2["text"].lower():
-                return "Permission to terminate conflicts with prohibition on termination"
-        
+                return (
+                    "Permission to terminate conflicts with prohibition on termination"
+                )
+
         if prop2.get("is_permission") and prop1.get("is_prohibition"):
             if prop2.get("can_terminate") and "terminate" in prop1["text"].lower():
-                return "Permission to terminate conflicts with prohibition on termination"
-        
+                return (
+                    "Permission to terminate conflicts with prohibition on termination"
+                )
+
         return None
-    
-    def _check_exclusivity_conflict(self, prop1: dict, prop2: dict) -> Optional[str]:
+
+    def _check_exclusivity_conflict(
+        self, prop1: dict, prop2: dict
+    ) -> Optional[str]:
         """Check for exclusivity conflicts."""
         if prop1.get("is_exclusive") and prop2.get("is_exclusive"):
             parties1 = prop1.get("parties", set())
             parties2 = prop2.get("parties", set())
-            if parties1 & parties2:  # Overlapping parties
+            if parties1 & parties2:
                 return "Multiple exclusive rights granted to same party"
-        
+
         return None
-    
+
     def _has_termination(self, text: str) -> bool:
         """Check if clause discusses termination."""
         terms = ["terminate", "termination", "cancel", "end the agreement"]
         return any(t in text for t in terms)
-    
+
     def _extract_days(self, text: str, context: str) -> Optional[int]:
         """Extract number of days from text near a context word."""
         if context not in text:
             return None
-        
-        # Find numbers near the context word
-        pattern = rf'(\d+)\s*(?:calendar\s+)?(?:business\s+)?days?\s*{context}'
+
+        pattern = rf"(\d+)\s*(?:calendar\s+)?(?:business\s+)?days?\s*{context}"
         match = re.search(pattern, text)
         if match:
             return int(match.group(1))
-        
-        pattern = rf'{context}\s*(\d+)\s*(?:calendar\s+)?(?:business\s+)?days?'
+
+        pattern = rf"{context}\s*(\d+)\s*(?:calendar\s+)?(?:business\s+)?days?"
         match = re.search(pattern, text)
         if match:
             return int(match.group(1))
-        
+
         return None
-    
+
     def _extract_parties(self, text: str) -> set:
         """Extract party names from clause."""
         parties = set()
-        for party in ["seller", "buyer", "vendor", "customer", "licensee", "licensor", 
-                      "party", "parties", "company", "contractor"]:
+        for party in [
+            "seller",
+            "buyer",
+            "vendor",
+            "customer",
+            "licensee",
+            "licensor",
+            "party",
+            "parties",
+            "company",
+            "contractor",
+        ]:
             if party in text:
                 parties.add(party)
         return parties
-    
-    def verify_using_z3(self, constraints: List[str]) -> ClauseResult:
+
+    def verify_using_z3(self, constraints: List[Any]) -> ClauseResult:
         """
-        Advanced: Verify constraints directly using Z3 formulas.
-        
-        For power users who want to define precise logical constraints.
-        
+        Advanced: Verify already-modeled Z3 constraints.
+
+        This method does not parse free-form legal text. Callers must provide
+        explicit Z3 expressions that already encode the legal meaning they want
+        checked.
+
         Args:
-            constraints: List of Z3-compatible constraint descriptions
-        
+            constraints: List of Z3 expressions
+
         Returns:
             ClauseResult indicating if constraints are satisfiable
         """
+        if not constraints:
+            return ClauseResult(
+                consistent=False,
+                conflicts=[],
+                message=(
+                    "UNVERIFIABLE: verify_using_z3 requires explicit Z3 "
+                    "constraint expressions. Empty input cannot be proven."
+                ),
+            )
+
+        invalid_positions = [
+            index + 1
+            for index, constraint in enumerate(constraints)
+            if not isinstance(constraint, ExprRef)
+        ]
+        if invalid_positions:
+            positions = ", ".join(str(position) for position in invalid_positions)
+            return ClauseResult(
+                consistent=False,
+                conflicts=[],
+                message=(
+                    "UNVERIFIABLE: verify_using_z3 only accepts explicit Z3 "
+                    f"expressions. Unsupported constraint(s) at position(s): {positions}."
+                ),
+            )
+
         solver = Solver()
-        
-        # Create boolean variables for each constraint
-        variables = {}
-        for i, constraint in enumerate(constraints):
-            var_name = f"c{i}"
-            variables[var_name] = Bool(var_name)
-            # Add constraint as true (we want to check if all can be satisfied)
-            solver.add(variables[var_name])
-        
+        solver.add(*constraints)
         result = solver.check()
-        
+
         if result == sat:
             return ClauseResult(
                 consistent=True,
                 conflicts=[],
-                message="✅ VERIFIED: Constraints are satisfiable."
+                message="VERIFIED: Provided Z3 constraints are satisfiable.",
             )
-        elif result == unsat:
+
+        if result == unsat:
             return ClauseResult(
                 consistent=False,
                 conflicts=[],
-                message="❌ ERROR: Constraints are unsatisfiable (contradiction exists)."
+                message=(
+                    "ERROR: Provided Z3 constraints are unsatisfiable "
+                    "(contradiction exists)."
+                ),
             )
-        else:
+
+        if result == unknown:
             return ClauseResult(
-                consistent=True,  # Unknown defaults to consistent
+                consistent=False,
                 conflicts=[],
-                message="⚠️ WARNING: Z3 could not determine satisfiability."
+                message="UNVERIFIABLE: Z3 returned unknown for the provided constraints.",
             )
+
+        return ClauseResult(
+            consistent=False,
+            conflicts=[],
+            message="UNVERIFIABLE: Z3 returned an unsupported satisfiability state.",
+        )

--- a/tests/test_guards.py
+++ b/tests/test_guards.py
@@ -1,5 +1,7 @@
 """Tests for QWED-Legal guards."""
 
+from unittest.mock import patch
+
 import pytest
 from z3 import Int
 
@@ -136,6 +138,26 @@ class TestClauseGuard:
         # Should detect conflict between permission and prohibition
         assert result.consistent is False or len(result.conflicts) >= 0
 
+    def test_termination_conflict_detected_in_reverse_order(self):
+        """Reverse ordering should still detect the termination/minimum-term conflict."""
+        guard = ClauseGuard()
+        result = guard.check_consistency([
+            "Neither party may terminate before 90 days",
+            "Seller may terminate with 30 days notice",
+        ])
+        assert result.consistent is False
+        assert any("minimum term" in reason for _, _, reason in result.conflicts)
+
+    def test_exclusivity_conflict_for_same_party(self):
+        """Exclusive rights granted twice to the same modeled party should conflict."""
+        guard = ClauseGuard()
+        result = guard.check_consistency([
+            "Seller has exclusive distribution rights in Region A.",
+            "Seller has exclusive distribution rights in Region B.",
+        ])
+        assert result.consistent is False
+        assert any("exclusive rights" in reason for _, _, reason in result.conflicts)
+
     def test_verify_using_z3_rejects_raw_text_constraints(self):
         """Raw text constraints should fail closed instead of pretending to be proven."""
         guard = ClauseGuard()
@@ -143,6 +165,13 @@ class TestClauseGuard:
             "The agreement must last exactly 12 months.",
             "The agreement must last exactly 24 months.",
         ])
+        assert result.consistent is False
+        assert "UNVERIFIABLE" in result.message
+
+    def test_verify_using_z3_empty_constraints_fail_closed(self):
+        """Empty constraints must not be reported as verified."""
+        guard = ClauseGuard()
+        result = guard.verify_using_z3([])
         assert result.consistent is False
         assert "UNVERIFIABLE" in result.message
 
@@ -161,6 +190,24 @@ class TestClauseGuard:
         result = guard.verify_using_z3([months == 12, months == 24])
         assert result.consistent is False
         assert "unsatisfiable" in result.message.lower()
+
+    def test_verify_using_z3_handles_unknown_fail_closed(self):
+        """Z3 unknown must not default to consistent."""
+        guard = ClauseGuard()
+        months = Int("months")
+        with patch("qwed_legal.guards.clause_guard.Solver.check", return_value="unknown"):
+            result = guard.verify_using_z3([months >= 12])
+        assert result.consistent is False
+        assert "UNVERIFIABLE" in result.message
+
+    def test_verify_using_z3_handles_unexpected_solver_state_fail_closed(self):
+        """Unexpected solver states must also fail closed."""
+        guard = ClauseGuard()
+        months = Int("months")
+        with patch("qwed_legal.guards.clause_guard.Solver.check", return_value="mystery"):
+            result = guard.verify_using_z3([months >= 12])
+        assert result.consistent is False
+        assert "unsupported satisfiability state" in result.message.lower()
 
 
 class TestCitationGuard:

--- a/tests/test_guards.py
+++ b/tests/test_guards.py
@@ -1,6 +1,7 @@
 """Tests for QWED-Legal guards."""
 
 import pytest
+from z3 import Int
 
 from qwed_legal import LegalGuard, DeadlineGuard, LiabilityGuard, ClauseGuard, CitationGuard
 
@@ -134,6 +135,32 @@ class TestClauseGuard:
         ])
         # Should detect conflict between permission and prohibition
         assert result.consistent is False or len(result.conflicts) >= 0
+
+    def test_verify_using_z3_rejects_raw_text_constraints(self):
+        """Raw text constraints should fail closed instead of pretending to be proven."""
+        guard = ClauseGuard()
+        result = guard.verify_using_z3([
+            "The agreement must last exactly 12 months.",
+            "The agreement must last exactly 24 months.",
+        ])
+        assert result.consistent is False
+        assert "UNVERIFIABLE" in result.message
+
+    def test_verify_using_z3_accepts_modeled_sat_constraints(self):
+        """Explicit Z3 constraints should still be checkable."""
+        guard = ClauseGuard()
+        months = Int("months")
+        result = guard.verify_using_z3([months >= 12, months <= 24])
+        assert result.consistent is True
+        assert "satisfiable" in result.message.lower()
+
+    def test_verify_using_z3_detects_unsat_modeled_constraints(self):
+        """Contradictory explicit Z3 constraints should return unsat."""
+        guard = ClauseGuard()
+        months = Int("months")
+        result = guard.verify_using_z3([months == 12, months == 24])
+        assert result.consistent is False
+        assert "unsatisfiable" in result.message.lower()
 
 
 class TestCitationGuard:

--- a/tests/test_guards.py
+++ b/tests/test_guards.py
@@ -3,7 +3,7 @@
 from unittest.mock import patch
 
 import pytest
-from z3 import Int
+from z3 import Int, unknown as z3_unknown
 
 from qwed_legal import LegalGuard, DeadlineGuard, LiabilityGuard, ClauseGuard, CitationGuard
 
@@ -195,10 +195,11 @@ class TestClauseGuard:
         """Z3 unknown must not default to consistent."""
         guard = ClauseGuard()
         months = Int("months")
-        with patch("qwed_legal.guards.clause_guard.Solver.check", return_value="unknown"):
+        with patch("qwed_legal.guards.clause_guard.Solver.check", return_value=z3_unknown):
             result = guard.verify_using_z3([months >= 12])
         assert result.consistent is False
         assert "UNVERIFIABLE" in result.message
+        assert "Z3 returned unknown" in result.message
 
     def test_verify_using_z3_handles_unexpected_solver_state_fail_closed(self):
         """Unexpected solver states must also fail closed."""


### PR DESCRIPTION
## Summary
This PR fixes issue #10 by removing ClauseGuard’s fake satisfiability path and making `verify_using_z3()` fail closed unless callers provide actual Z3 expressions.

Previously, `verify_using_z3()` accepted raw constraint strings but never modeled their meaning. It created independent boolean variables, asserted them as true, and could report satisfiable even when the input constraints were logically contradictory.

## What changed
- `verify_using_z3()` now accepts only explicit Z3 expressions
- raw text constraints now return `UNVERIFIABLE` instead of a success-like satisfiable result
- empty constraint lists now fail closed
- Z3 `unknown` no longer defaults to consistent
- added regression tests for:
  - raw-text rejection
  - satisfiable modeled constraints
  - unsatisfiable modeled constraints

## Why
`ClauseGuard.verify_using_z3()` should not claim formal verification unless legal meaning has actually been modeled.

If constraints are not explicitly encoded as Z3 expressions, the method cannot prove satisfiability and must fail closed.

## Result
`verify_using_z3()` no longer presents unsupported raw legal text as formally verified Z3 logic.

Closes #10


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified clause checks are heuristic-driven (not full formal proof); messaging now reflects "supported clause checks" and flags potential conflicts. Verification is stricter: raw/empty inputs are treated as un-verifiable with fail-closed behavior; typed solver inputs report verified/error/unverifiable based on satisfiability.

* **Tests**
  * Added tests for conflict detection (order-independence, duplicate exclusive-rights) and for robust verification reporting, including indeterminate solver outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->