### PR TITLE
fix(statute-guard): fail-closed on unknown jurisdictions and claim types (#14)

### DIFF
--- a/npm/src/index.ts
+++ b/npm/src/index.ts
@@ -65,12 +65,14 @@ export interface StatuteResult {
     verified: boolean;
     claim_type: string;
     jurisdiction: string;
-    incident_date: string;
-    filing_date: string;
-    limitation_period_years: number;
-    expiration_date: string;
-    days_remaining: number;
+    incident_date: string | null;
+    filing_date: string | null;
+    limitation_period_years: number | null;
+    expiration_date: string | null;
+    days_remaining: number | null;
     message: string;
+    jurisdiction_matched: boolean;
+    claim_type_matched: boolean;
 }
 
 // ============================================================================
@@ -382,7 +384,9 @@ print(json.dumps({
     "limitation_period_years": result.limitation_period_years,
     "expiration_date": result.expiration_date.isoformat() if result.expiration_date else None,
     "days_remaining": result.days_remaining,
-    "message": result.message
+    "message": result.message,
+    "jurisdiction_matched": result.jurisdiction_matched,
+    "claim_type_matched": result.claim_type_matched
 }))
 `;
         return runPythonScript<StatuteResult>(script, this.pythonPath);
@@ -394,7 +398,7 @@ print(json.dumps({
     async getLimitationPeriod(
         claimType: string,
         jurisdiction: string
-    ): Promise<number> {
+    ): Promise<number | null> {
         const script = `
 from qwed_legal import StatuteOfLimitationsGuard
 import json
@@ -404,7 +408,7 @@ period = guard.get_limitation_period("${escapePythonString(claimType)}", "${esca
 
 print(json.dumps(period))
 `;
-        return runPythonScript<number>(script, this.pythonPath);
+        return runPythonScript<number | null>(script, this.pythonPath);
     }
 }
 

--- a/qwed_legal/guards/statute_guard.py
+++ b/qwed_legal/guards/statute_guard.py
@@ -230,19 +230,6 @@ class StatuteOfLimitationsGuard:
         },
     }
     
-    # Default limitation period if jurisdiction not found
-    DEFAULT_LIMITATIONS: Dict[str, float] = {
-        "breach_of_contract": 4.0,
-        "breach_of_warranty": 4.0,
-        "negligence": 3.0,
-        "professional_malpractice": 3.0,
-        "fraud": 6.0,
-        "personal_injury": 3.0,
-        "property_damage": 3.0,
-        "employment": 3.0,
-        "product_liability": 3.0,
-        "defamation": 1.0,
-    }
     
     def __init__(self):
         """Initialize StatuteOfLimitationsGuard."""

--- a/qwed_legal/guards/statute_guard.py
+++ b/qwed_legal/guards/statute_guard.py
@@ -33,12 +33,14 @@ class StatuteResult:
     verified: bool
     claim_type: str
     jurisdiction: str
-    incident_date: datetime
-    filing_date: datetime
-    limitation_period_years: float
-    expiration_date: datetime
-    days_remaining: int
+    incident_date: Optional[datetime]
+    filing_date: Optional[datetime]
+    limitation_period_years: Optional[float]
+    expiration_date: Optional[datetime]
+    days_remaining: Optional[int]
     message: str
+    jurisdiction_matched: bool = True  # False if jurisdiction is unknown
+    claim_type_matched: bool = True    # False if claim type is unknown
 
 
 class StatuteOfLimitationsGuard:
@@ -276,31 +278,65 @@ class StatuteOfLimitationsGuard:
                 verified=False,
                 claim_type=claim_type,
                 jurisdiction=jurisdiction,
-                incident_date=datetime.min,
-                filing_date=datetime.min,
-                limitation_period_years=0,
-                expiration_date=datetime.min,
-                days_remaining=0,
-                message=f"Failed to parse dates: {e}"
+                incident_date=None,
+                filing_date=None,
+                limitation_period_years=None,
+                expiration_date=None,
+                days_remaining=None,
+                message=f"Failed to parse dates: {e}",
+                jurisdiction_matched=False,
+                claim_type_matched=False,
             )
         
         # Get limitation period
         claim_type_lower = claim_type.lower().replace(" ", "_")
         jurisdiction_upper = jurisdiction.upper().strip()
         
-        # Look up limitation period
-        if jurisdiction_upper in self.LIMITATIONS:
-            limits = self.LIMITATIONS[jurisdiction_upper]
-        else:
-            # Try partial match
-            matched = None
-            for key in self.LIMITATIONS:
-                if key in jurisdiction_upper or jurisdiction_upper in key:
-                    matched = key
-                    break
-            limits = self.LIMITATIONS.get(matched, self.DEFAULT_LIMITATIONS)
+        # Fail-closed: exact jurisdiction match only (no partial matching)
+        if jurisdiction_upper not in self.LIMITATIONS:
+            return StatuteResult(
+                verified=False,
+                claim_type=claim_type,
+                jurisdiction=jurisdiction,
+                incident_date=incident,
+                filing_date=filing,
+                limitation_period_years=None,
+                expiration_date=None,
+                days_remaining=None,
+                message=(
+                    f"⚠️ UNVERIFIABLE: Jurisdiction '{jurisdiction}' is not "
+                    f"in the supported jurisdiction list. Cannot determine "
+                    f"applicable statute of limitations. Supported: "
+                    f"{', '.join(sorted(self.LIMITATIONS.keys()))}."
+                ),
+                jurisdiction_matched=False,
+                claim_type_matched=False,
+            )
         
-        period_years = limits.get(claim_type_lower, 3.0)
+        limits = self.LIMITATIONS[jurisdiction_upper]
+        
+        # Fail-closed: exact claim type match only (no default fallback)
+        if claim_type_lower not in limits:
+            return StatuteResult(
+                verified=False,
+                claim_type=claim_type,
+                jurisdiction=jurisdiction,
+                incident_date=incident,
+                filing_date=filing,
+                limitation_period_years=None,
+                expiration_date=None,
+                days_remaining=None,
+                message=(
+                    f"⚠️ UNVERIFIABLE: Claim type '{claim_type}' is not "
+                    f"recognized for jurisdiction '{jurisdiction}'. Cannot "
+                    f"determine limitation period. Supported claim types: "
+                    f"{', '.join(sorted(limits.keys()))}."
+                ),
+                jurisdiction_matched=True,
+                claim_type_matched=False,
+            )
+        
+        period_years = limits[claim_type_lower]
         
         # Calculate expiration date
         expiration = incident + relativedelta(years=int(period_years))
@@ -346,7 +382,7 @@ class StatuteOfLimitationsGuard:
         self,
         claim_type: str,
         jurisdiction: str
-    ) -> float:
+    ) -> Optional[float]:
         """
         Get the limitation period for a claim type in a jurisdiction.
         
@@ -355,24 +391,25 @@ class StatuteOfLimitationsGuard:
             jurisdiction: State or country
             
         Returns:
-            Limitation period in years
+            Limitation period in years, or None if jurisdiction/claim unknown
         """
         claim_type_lower = claim_type.lower().replace(" ", "_")
         jurisdiction_upper = jurisdiction.upper().strip()
         
-        if jurisdiction_upper in self.LIMITATIONS:
-            return self.LIMITATIONS[jurisdiction_upper].get(
-                claim_type_lower, 
-                self.DEFAULT_LIMITATIONS.get(claim_type_lower, 3.0)
-            )
+        if jurisdiction_upper not in self.LIMITATIONS:
+            return None
         
-        return self.DEFAULT_LIMITATIONS.get(claim_type_lower, 3.0)
+        limits = self.LIMITATIONS[jurisdiction_upper]
+        if claim_type_lower not in limits:
+            return None
+        
+        return limits[claim_type_lower]
     
     def compare_jurisdictions(
         self,
         claim_type: str,
         jurisdictions: list
-    ) -> Dict[str, float]:
+    ) -> Dict[str, Optional[float]]:
         """
         Compare limitation periods across jurisdictions.
         
@@ -381,7 +418,7 @@ class StatuteOfLimitationsGuard:
             jurisdictions: List of jurisdictions to compare
             
         Returns:
-            Dict mapping jurisdiction to limitation period
+            Dict mapping jurisdiction to limitation period (None if unknown)
         """
         return {
             j: self.get_limitation_period(claim_type, j)

--- a/tests/test_statute_fail_closed.py
+++ b/tests/test_statute_fail_closed.py
@@ -1,0 +1,179 @@
+"""
+Tests for StatuteOfLimitationsGuard fail-closed enforcement (Issue #14).
+
+Covers:
+- Unknown jurisdictions return UNVERIFIABLE
+- Unknown claim types return UNVERIFIABLE
+- Partial string matching is eliminated
+- Valid jurisdiction + claim type still works
+- get_limitation_period returns None for unknowns
+"""
+
+from qwed_legal import StatuteOfLimitationsGuard
+
+
+class TestStatuteGuardFailClosed:
+    """Issue #14: StatuteGuard must not fabricate limitation periods."""
+
+    def setup_method(self):
+        self.guard = StatuteOfLimitationsGuard()
+
+    # ── Unknown jurisdictions ─────────────────────────────────────
+
+    def test_unknown_jurisdiction_is_unverifiable(self):
+        """'Mars Colony' is not a real jurisdiction — must fail closed."""
+        result = self.guard.verify(
+            claim_type="breach_of_contract",
+            jurisdiction="Mars Colony",
+            incident_date="2020-01-01",
+            filing_date="2022-01-01",
+        )
+        assert result.verified is False
+        assert result.jurisdiction_matched is False
+        assert result.limitation_period_years is None
+        assert result.expiration_date is None
+        assert "UNVERIFIABLE" in result.message
+
+    def test_gibberish_jurisdiction_is_unverifiable(self):
+        """Random string jurisdiction — must fail closed."""
+        result = self.guard.verify(
+            claim_type="negligence",
+            jurisdiction="xyzabc123",
+            incident_date="2020-01-01",
+            filing_date="2022-01-01",
+        )
+        assert result.verified is False
+        assert result.jurisdiction_matched is False
+        assert "UNVERIFIABLE" in result.message
+
+    def test_partial_match_no_longer_works(self):
+        """'CALIF' should NOT partially match 'CALIFORNIA' — fail closed."""
+        result = self.guard.verify(
+            claim_type="breach_of_contract",
+            jurisdiction="CALIF",
+            incident_date="2020-01-01",
+            filing_date="2022-01-01",
+        )
+        assert result.verified is False
+        assert result.jurisdiction_matched is False
+        assert "UNVERIFIABLE" in result.message
+
+    def test_substring_jurisdiction_no_longer_matches(self):
+        """'NEW' should NOT match 'NEW YORK' — fail closed."""
+        result = self.guard.verify(
+            claim_type="fraud",
+            jurisdiction="NEW",
+            incident_date="2020-01-01",
+            filing_date="2022-01-01",
+        )
+        assert result.verified is False
+        assert result.jurisdiction_matched is False
+
+    def test_superset_jurisdiction_no_longer_matches(self):
+        """'CALIFORNIA STATE' should NOT match 'CALIFORNIA' — fail closed."""
+        result = self.guard.verify(
+            claim_type="negligence",
+            jurisdiction="CALIFORNIA STATE",
+            incident_date="2020-01-01",
+            filing_date="2022-01-01",
+        )
+        assert result.verified is False
+        assert result.jurisdiction_matched is False
+
+    # ── Unknown claim types ───────────────────────────────────────
+
+    def test_unknown_claim_type_is_unverifiable(self):
+        """'antitrust' is not in the supported claim types — must fail closed."""
+        result = self.guard.verify(
+            claim_type="antitrust",
+            jurisdiction="California",
+            incident_date="2020-01-01",
+            filing_date="2022-01-01",
+        )
+        assert result.verified is False
+        assert result.jurisdiction_matched is True
+        assert result.claim_type_matched is False
+        assert result.limitation_period_years is None
+        assert "UNVERIFIABLE" in result.message
+
+    def test_gibberish_claim_type_is_unverifiable(self):
+        """Random claim type — must fail closed."""
+        result = self.guard.verify(
+            claim_type="space_piracy",
+            jurisdiction="New York",
+            incident_date="2020-01-01",
+            filing_date="2022-01-01",
+        )
+        assert result.verified is False
+        assert result.claim_type_matched is False
+        assert "UNVERIFIABLE" in result.message
+
+    # ── Valid inputs still work ────────────────────────────────────
+
+    def test_valid_california_breach_of_contract(self):
+        """Known jurisdiction + known claim type — must still verify."""
+        result = self.guard.verify(
+            claim_type="breach_of_contract",
+            jurisdiction="California",
+            incident_date="2024-01-15",
+            filing_date="2026-06-01",
+        )
+        assert result.verified is True
+        assert result.jurisdiction_matched is True
+        assert result.claim_type_matched is True
+        assert result.limitation_period_years == 4.0
+        assert "WITHIN" in result.message
+
+    def test_valid_expired_claim(self):
+        """Valid inputs but expired — verified=False, but still matched."""
+        result = self.guard.verify(
+            claim_type="breach_of_contract",
+            jurisdiction="California",
+            incident_date="2018-01-15",
+            filing_date="2026-06-01",
+        )
+        assert result.verified is False
+        assert result.jurisdiction_matched is True
+        assert result.claim_type_matched is True
+        assert "EXPIRED" in result.message
+
+    # ── get_limitation_period fail-closed ──────────────────────────
+
+    def test_get_period_unknown_jurisdiction_returns_none(self):
+        """get_limitation_period must return None for unknown jurisdiction."""
+        period = self.guard.get_limitation_period("breach_of_contract", "Mars")
+        assert period is None
+
+    def test_get_period_unknown_claim_type_returns_none(self):
+        """get_limitation_period must return None for unknown claim type."""
+        period = self.guard.get_limitation_period("antitrust", "California")
+        assert period is None
+
+    def test_get_period_valid_returns_value(self):
+        """get_limitation_period for known inputs still works."""
+        period = self.guard.get_limitation_period("breach_of_contract", "California")
+        assert period == 4.0
+
+    # ── compare_jurisdictions with unknowns ────────────────────────
+
+    def test_compare_with_unknown_jurisdiction_returns_none(self):
+        """compare_jurisdictions includes None for unknown jurisdictions."""
+        comparison = self.guard.compare_jurisdictions(
+            "breach_of_contract", ["California", "Mars Colony"]
+        )
+        assert comparison["California"] == 4.0
+        assert comparison["Mars Colony"] is None
+
+    # ── Date parsing errors ───────────────────────────────────────
+
+    def test_invalid_date_fails_closed(self):
+        """Unparseable date — must fail closed."""
+        result = self.guard.verify(
+            claim_type="breach_of_contract",
+            jurisdiction="California",
+            incident_date="not-a-date",
+            filing_date="2026-01-01",
+        )
+        assert result.verified is False
+        assert result.jurisdiction_matched is False
+        assert result.incident_date is None


### PR DESCRIPTION
Closes #14

## Summary

`StatuteOfLimitationsGuard` no longer fabricates limitation periods for unknown jurisdictions and claim types.

---

## Problem

Three fail-open paths existed:

**1. Partial string matching (L294–300):**

```python
for key in self.LIMITATIONS:
    if key in jurisdiction_upper or jurisdiction_upper in key:
        matched = key  # "CALIF" matches "CALIFORNIA", "NEW" matches "NEW YORK"
```

**2. Default fallback for unknown jurisdictions (L301):**

```python
limits = self.LIMITATIONS.get(matched, self.DEFAULT_LIMITATIONS)  # Fabricates rules
```

**3. Silent default for unknown claim types (L303):**

```python
period_years = limits.get(claim_type_lower, 3.0)  # Invents 3 years
```

---

## Fix

Two fail-closed gates:

1. **Unknown jurisdiction → `UNVERIFIABLE`** (lists supported jurisdictions)
2. **Unknown claim type → `UNVERIFIABLE`** (lists supported claim types for that jurisdiction)

All three methods updated:
- `verify()` — returns fail-closed `StatuteResult`
- `get_limitation_period()` — returns `None` instead of default
- `compare_jurisdictions()` — includes `None` for unknowns

---

## Breaking Changes

| Change | Before | After |
|---|---|---|
| Partial jurisdiction matching | `"CALIF"` → `"CALIFORNIA"` | Exact match only |
| Unknown jurisdiction | `DEFAULT_LIMITATIONS` fallback | `UNVERIFIABLE` |
| Unknown claim type | Default `3.0` years | `UNVERIFIABLE` |
| `get_limitation_period()` return | `float` (always a number) | `Optional[float]` (`None` if unknown) |
| `StatuteResult` fields | Always populated | `Optional` (`None` if unverifiable) |
| New fields | — | `jurisdiction_matched`, `claim_type_matched` |

---

## Tests

115 tests pass (5 existing + 14 new regression tests) — zero regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Statute of limitations verification now enforces exact jurisdiction and claim type matching, preventing unintended partial matches.
  * Enhanced error handling for invalid date inputs, returning unverified results instead of falling back to defaults.

* **Tests**
  * Added comprehensive test suite for statute of limitations validation edge cases and fail-safe behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QWED-AI/qwed-legal/pull/25)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->