### PR TITLE
fix(guards): fail-closed enforcement for unsupported legal domains — closes #20

### DIFF
--- a/action_entrypoint.py
+++ b/action_entrypoint.py
@@ -14,7 +14,7 @@ from qwed_legal import DeadlineGuard, LiabilityGuard, ClauseGuard, CitationGuard
 
 def set_output(name: str, value: str):
     """Set GitHub Action output using heredoc delimiter format."""
-    output_file = os.environ.get('GITHUB_OUTPUT')
+    output_file = os.environ.get("GITHUB_OUTPUT")
     if output_file:
         # Sanitize the output name (no newlines)
         safe_name = name.replace("\r", "").replace("\n", "")
@@ -22,7 +22,7 @@ def set_output(name: str, value: str):
         delimiter = "ghadelimiter_qwed"
         while delimiter in value:
             delimiter += "_x"
-        with open(output_file, 'a', encoding='utf-8') as f:
+        with open(output_file, "a", encoding="utf-8") as f:
             f.write(f"{safe_name}<<{delimiter}\n{value}\n{delimiter}\n")
     else:
         print(f"::set-output name={name}::{value}")
@@ -30,9 +30,9 @@ def set_output(name: str, value: str):
 
 def main():
     args = sys.argv[1:]
-    
+
     # Parse arguments
-    mode = args[0] if len(args) > 0 and args[0] else 'all'
+    mode = args[0] if len(args) > 0 and args[0] else "all"
     signing_date = args[1] if len(args) > 1 and args[1] else None
     term = args[2] if len(args) > 2 and args[2] else None
     claimed_deadline = args[3] if len(args) > 3 and args[3] else None
@@ -41,89 +41,101 @@ def main():
     claimed_cap = args[6] if len(args) > 6 and args[6] else None
     clauses_json = args[7] if len(args) > 7 and args[7] else None
     citation = args[8] if len(args) > 8 and args[8] else None
-    country = args[9] if len(args) > 9 and args[9] else 'US'
+    country = args[9] if len(args) > 9 and args[9] else "US"
     state = args[10] if len(args) > 10 and args[10] else None
-    
+
     results = {}
     all_verified = True
     messages = []
-    
+
     # Deadline verification
-    if mode in ['deadline', 'all'] and signing_date and term and claimed_deadline:
+    if mode in ["deadline", "all"] and signing_date and term and claimed_deadline:
         guard = DeadlineGuard(country=country, state=state)
         result = guard.verify(signing_date, term, claimed_deadline)
-        results['deadline'] = {
-            'verified': result.verified,
-            'computed': result.computed_deadline.isoformat() if result.computed_deadline else None,
-            'claimed': claimed_deadline,
-            'difference_days': result.difference_days,
-            'message': result.message,
+        results["deadline"] = {
+            "verified": result.verified,
+            "computed": (
+                result.computed_deadline.isoformat()
+                if result.computed_deadline
+                else None
+            ),
+            "claimed": claimed_deadline,
+            "difference_days": result.difference_days,
+            "message": result.message,
         }
         if not result.verified:
             all_verified = False
         messages.append(result.message)
         print(result.message)
-    
+
     # Liability verification
-    if mode in ['liability', 'all'] and contract_value and cap_percentage and claimed_cap:
+    if (
+        mode in ["liability", "all"]
+        and contract_value
+        and cap_percentage
+        and claimed_cap
+    ):
         guard = LiabilityGuard()
         result = guard.verify_cap(
-            float(contract_value),
-            float(cap_percentage),
-            float(claimed_cap)
+            float(contract_value), float(cap_percentage), float(claimed_cap)
         )
-        results['liability'] = {
-            'verified': result.verified,
-            'computed': float(result.computed_cap),
-            'claimed': float(claimed_cap),
-            'difference': float(result.difference),
-            'message': result.message,
+        results["liability"] = {
+            "verified": result.verified,
+            "computed": float(result.computed_cap),
+            "claimed": float(claimed_cap),
+            "difference": float(result.difference),
+            "message": result.message,
         }
         if not result.verified:
             all_verified = False
         messages.append(result.message)
         print(result.message)
-    
+
     # Clause verification
-    if mode in ['clause', 'all'] and clauses_json:
+    if mode in ["clause", "all"] and clauses_json:
         try:
             clauses = json.loads(clauses_json)
             guard = ClauseGuard()
             result = guard.check_consistency(clauses)
-            results['clause'] = {
-                'consistent': result.consistent,
-                'conflicts': [(c[0], c[1], c[2]) for c in result.conflicts],
-                'message': result.message,
+            results["clause"] = {
+                "consistent": result.consistent,
+                "status": result.status,
+                "conflicts": [(c[0], c[1], c[2]) for c in result.conflicts],
+                "message": result.message,
             }
-            if not result.consistent:
+            # heuristic_pass_limited = guard has no coverage, not a detected
+            # contradiction — do NOT fail CI for this case.
+            if result.status == "contradiction":
                 all_verified = False
             messages.append(result.message)
             print(result.message)
         except json.JSONDecodeError as e:
-            results['clause'] = {'error': f'Invalid JSON: {e}'}
+            results["clause"] = {"error": f"Invalid JSON: {e}"}
             all_verified = False
-    
+
     # Citation verification
-    if mode in ['citation', 'all'] and citation:
+    if mode in ["citation", "all"] and citation:
         guard = CitationGuard()
         result = guard.verify(citation)
-        results['citation'] = {
-            'valid': result.valid,
-            'citation_type': result.citation_type,
-            'parsed': result.parsed_components,
-            'issues': result.issues,
-            'message': result.message,
+        results["citation"] = {
+            "valid": result.valid,
+            "citation_type": result.citation_type,
+            "parsed": result.parsed_components,
+            "issues": result.issues,
+            "message": result.message,
         }
         if not result.valid:
             all_verified = False
         messages.append(result.message)
         print(result.message)
-    
+
     # Set outputs
-    set_output('verified', str(all_verified).lower())
-    set_output('results', json.dumps(results))
-    set_output('message', ' | '.join(messages) if messages else 'No verification performed')
-    
+    set_output("verified", str(all_verified).lower())
+    set_output("results", json.dumps(results))
+    set_output(
+        "message", " | ".join(messages) if messages else "No verification performed"
+    )
+
     # Exit with error if verification failed
     if not all_verified:
         print("\n🛑 QWED Legal: Verification FAILED")
@@ -133,5 +145,5 @@ def main():
         sys.exit(0)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/qwed_legal/guards/clause_guard.py
+++ b/qwed_legal/guards/clause_guard.py
@@ -65,11 +65,40 @@ class ClauseGuard:
         # Check for conflicts using supported heuristics
         conflicts = self._find_conflicts(propositions)
 
+        # Count how many propositions had any extractable content.
+        # If none of the clauses triggered a recognizable proposition, the
+        # heuristic had no coverage — returning "VERIFIED" would be misleading.
+        covered = sum(
+            1
+            for p in propositions
+            if p["can_terminate"]
+            or p["termination_notice_days"] is not None
+            or p["min_term_days"] is not None
+            or p["is_exclusive"]
+        )
+
         if not conflicts:
+            if covered == 0:
+                return ClauseResult(
+                    consistent=False,
+                    conflicts=[],
+                    message=(
+                        "HEURISTIC_PASS (LIMITED COVERAGE): No heuristic propositions "
+                        "were extracted from the provided clauses. ClauseGuard only "
+                        "recognises termination, notice period, min-term, and exclusivity "
+                        "patterns. The clauses may be consistent, but this guard cannot "
+                        "confirm it — downstream consumers should not treat this as "
+                        "verified consistency."
+                    ),
+                )
             return ClauseResult(
                 consistent=True,
                 conflicts=[],
-                message="VERIFIED: All supported clause checks found no conflicts.",
+                message=(
+                    "HEURISTIC_PASS: Supported clause checks (termination, notice, "
+                    "min-term, exclusivity) found no conflicts. This is a heuristic "
+                    "result — not deterministic legal verification."
+                ),
             )
 
         conflict_msgs = []
@@ -109,9 +138,7 @@ class ClauseGuard:
 
         return propositions
 
-    def _find_conflicts(
-        self, propositions: List[dict]
-    ) -> List[Tuple[int, int, str]]:
+    def _find_conflicts(self, propositions: List[dict]) -> List[Tuple[int, int, str]]:
         """Find logical conflicts between clauses."""
         conflicts = []
 
@@ -136,9 +163,7 @@ class ClauseGuard:
 
         return conflicts
 
-    def _check_termination_conflict(
-        self, prop1: dict, prop2: dict
-    ) -> Optional[str]:
+    def _check_termination_conflict(self, prop1: dict, prop2: dict) -> Optional[str]:
         """Check for conflicting termination clauses."""
         if prop1.get("can_terminate") and prop2.get("min_term_days"):
             notice = prop1.get("termination_notice_days", 0)
@@ -178,9 +203,7 @@ class ClauseGuard:
 
         return None
 
-    def _check_exclusivity_conflict(
-        self, prop1: dict, prop2: dict
-    ) -> Optional[str]:
+    def _check_exclusivity_conflict(self, prop1: dict, prop2: dict) -> Optional[str]:
         """Check for exclusivity conflicts."""
         if prop1.get("is_exclusive") and prop2.get("is_exclusive"):
             parties1 = prop1.get("parties", set())

--- a/qwed_legal/guards/clause_guard.py
+++ b/qwed_legal/guards/clause_guard.py
@@ -19,6 +19,12 @@ class ClauseResult:
     consistent: bool
     conflicts: List[Tuple[int, int, str]]  # (clause_idx1, clause_idx2, reason)
     message: str
+    status: str = "consistent"
+    # status values:
+    #   "consistent"                  — heuristic checks found no conflicts
+    #   "contradiction"               — at least one conflict detected
+    #   "heuristic_pass_limited"      — no propositions extracted; guard has no coverage
+    #                                   consistent=False but NOT a detected contradiction
 
 
 class ClauseGuard:
@@ -82,18 +88,20 @@ class ClauseGuard:
                 return ClauseResult(
                     consistent=False,
                     conflicts=[],
+                    status="heuristic_pass_limited",
                     message=(
                         "HEURISTIC_PASS (LIMITED COVERAGE): No heuristic propositions "
                         "were extracted from the provided clauses. ClauseGuard only "
                         "recognises termination, notice period, min-term, and exclusivity "
                         "patterns. The clauses may be consistent, but this guard cannot "
-                        "confirm it — downstream consumers should not treat this as "
+                        "confirm it — downstream consumers must not treat this as "
                         "verified consistency."
                     ),
                 )
             return ClauseResult(
                 consistent=True,
                 conflicts=[],
+                status="consistent",
                 message=(
                     "HEURISTIC_PASS: Supported clause checks (termination, notice, "
                     "min-term, exclusivity) found no conflicts. This is a heuristic "
@@ -110,6 +118,7 @@ class ClauseGuard:
         return ClauseResult(
             consistent=False,
             conflicts=conflicts,
+            status="contradiction",
             message=(
                 f"WARNING: {len(conflicts)} potential conflict(s) detected:\n"
                 + "\n".join(conflict_msgs)

--- a/qwed_legal/guards/contradiction_guard.py
+++ b/qwed_legal/guards/contradiction_guard.py
@@ -3,15 +3,16 @@ ContradictionGuard: Detect logical contradictions in contract clauses using Z3.
 
 Fail-closed design:
   - Only DURATION and LIABILITY categories are modeled.
-  - Clauses with unsupported categories are not silently ignored.
-  - If NO clauses are translatable, returns UNVERIFIABLE instead of a false SAT.
-  - If SOME clauses are untranslatable, returns a partial-coverage warning.
+  - Unsupported categories are never silently ignored — UNVERIFIABLE is returned.
+  - Supported clauses with unmodeled keywords (no constraint added) are tracked
+    and cause partial_coverage — never verified=True for partial inputs.
+  - Z3 unknown result → UNVERIFIABLE (not a false contradiction).
 """
 
 from dataclasses import dataclass, field
 from typing import List
 
-from z3 import Int, Solver, sat
+from z3 import Int, Solver, sat, unknown
 
 
 @dataclass
@@ -35,124 +36,186 @@ class ContradictionGuard:
     Supported categories: DURATION, LIABILITY.
 
     Fail-closed:
-    - Clauses with unsupported categories (PAYMENT, PENALTY, etc.) are not
-      silently ignored — they trigger an UNVERIFIABLE result.
-    - If no supported clauses are present, returns UNVERIFIABLE instead of
-      a false SAT (absence of constraints does not mean consistency).
-    - If some clauses are unsupported, returns PARTIAL_COVERAGE with a warning.
+    - Unsupported categories → UNVERIFIABLE (never silently ignored).
+    - No supported clauses present → UNVERIFIABLE.
+    - Supported clauses whose keywords are not modeled → partial_coverage,
+      verified=False (constraint could not be encoded).
+    - Z3 unknown → UNVERIFIABLE (not a false contradiction).
     """
 
     def verify_consistency(self, clauses: List[Clause]) -> dict:
         """
-        Translate supported legal clauses into Z3 constraints and check for SAT.
+        Translate supported legal clauses into Z3 constraints and check SAT.
 
         Returns a dict with keys:
           verified     (bool)
-          status       (str)  — one of: consistent, contradiction, unverifiable, partial_coverage
+          status       (str) — consistent | contradiction | unverifiable | partial_coverage
           message      (str)
-          unsupported  (list) — categories not modeled by this guard
+          unsupported  (list[str]) — categories not modeled by this guard
         """
         if not clauses:
-            return {
-                "verified": False,
-                "status": "unverifiable",
-                "message": (
+            return self._unverifiable_result(
+                message=(
                     "UNVERIFIABLE: No clauses provided. "
                     "An empty clause list cannot be proven consistent."
                 ),
-                "unsupported": [],
-            }
+                unsupported=[],
+            )
 
-        # Partition clauses into supported and unsupported
+        supported, unsupported = self._partition_clauses(clauses)
+        unsupported_categories = sorted({c.category for c in unsupported})
+
+        if not supported:
+            return self._unverifiable_result(
+                message=(
+                    f"UNVERIFIABLE: None of the provided clause categories are modeled "
+                    f"by ContradictionGuard. Supported: "
+                    f"{', '.join(sorted(SUPPORTED_CATEGORIES))}. "
+                    f"Received unsupported: {', '.join(unsupported_categories)}. "
+                    f"Cannot prove consistency for inputs that are not modeled."
+                ),
+                unsupported=unsupported_categories,
+            )
+
+        s = Solver()
+        contract_duration_months = Int("contract_duration_months")
+        max_liability_usd = Int("max_liability_usd")
+        s.add(contract_duration_months >= 0)
+        s.add(max_liability_usd >= 0)
+
+        unmodeled_supported = 0
+
+        duration_clauses = [c for c in supported if c.category.upper() == "DURATION"]
+        for clause in duration_clauses:
+            unmodeled_supported += self._add_duration_constraint(
+                s, clause, contract_duration_months
+            )
+
+        liability_clauses = [c for c in supported if c.category.upper() == "LIABILITY"]
+        for clause in liability_clauses:
+            unmodeled_supported += self._add_liability_constraint(
+                s, clause, max_liability_usd
+            )
+
+        return self._build_result(
+            s=s,
+            unsupported_categories=unsupported_categories,
+            has_unsupported=bool(unsupported),
+            unmodeled_supported=unmodeled_supported,
+        )
+
+    # ── private helpers ────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _partition_clauses(clauses: List[Clause]):
+        """Split clauses into supported and unsupported categories."""
         supported = [c for c in clauses if c.category.upper() in SUPPORTED_CATEGORIES]
         unsupported = [
             c for c in clauses if c.category.upper() not in SUPPORTED_CATEGORIES
         ]
-        unsupported_categories = sorted({c.category for c in unsupported})
+        return supported, unsupported
 
-        # Fail closed: if there are NO supported clauses we cannot prove anything
-        if not supported:
+    @staticmethod
+    def _add_duration_constraint(s: Solver, clause: Clause, var: object) -> int:
+        """
+        Add a Z3 constraint for a DURATION clause.
+        Returns 1 if the clause keyword is not modeled (unmodeled), 0 otherwise.
+        """
+        text = clause.text.lower()
+        if "exactly" in text:
+            s.add(var == clause.value)
+        elif "minimum" in text or "at least" in text:
+            s.add(var >= clause.value)
+        elif "maximum" in text or "up to" in text:
+            s.add(var <= clause.value)
+        else:
+            return 1  # clause recognized as DURATION but keyword not modeled
+        return 0
+
+    @staticmethod
+    def _add_liability_constraint(s: Solver, clause: Clause, var: object) -> int:
+        """
+        Add a Z3 constraint for a LIABILITY clause.
+        Returns 1 if the clause keyword is not modeled (unmodeled), 0 otherwise.
+        """
+        text = clause.text.lower()
+        if "capped" in text or "max" in text or "cap" in text:
+            s.add(var <= clause.value)
+        elif "penalty" in text or "fixed" in text or "minimum" in text:
+            s.add(var >= clause.value)
+        else:
+            return 1  # clause recognized as LIABILITY but keyword not modeled
+        return 0
+
+    @staticmethod
+    def _unverifiable_result(message: str, unsupported: list) -> dict:
+        return {
+            "verified": False,
+            "status": "unverifiable",
+            "message": message,
+            "unsupported": unsupported,
+        }
+
+    @staticmethod
+    def _build_result(
+        s: Solver,
+        unsupported_categories: list,
+        has_unsupported: bool,
+        unmodeled_supported: int,
+    ) -> dict:
+        """Evaluate Z3 solver and build the final result dict."""
+        has_partial_modeling = has_unsupported or (unmodeled_supported > 0)
+
+        coverage_note = ""
+        if has_unsupported:
+            coverage_note = (
+                f" NOTE: clause(s) with unsupported categories "
+                f"({', '.join(unsupported_categories)}) were excluded from the Z3 model."
+            )
+        if unmodeled_supported > 0:
+            coverage_note += (
+                f" NOTE: {unmodeled_supported} supported-category clause(s) had "
+                f"unrecognized keyword patterns and could not be encoded."
+            )
+
+        result = s.check()
+
+        if result == sat:
+            status = "partial_coverage" if has_partial_modeling else "consistent"
+            # partial_coverage is NOT verified=True — modeling was incomplete
+            verified = status == "consistent"
+            return {
+                "verified": verified,
+                "status": status,
+                "message": (
+                    f"{'✅ CONSISTENT' if verified else '⚠️  PARTIAL COVERAGE'} "
+                    f"(modeled clauses): The DURATION and LIABILITY clauses "
+                    f"{'are logically satisfiable' if verified else 'passed, but modeling is incomplete'}"
+                    f".{coverage_note}"
+                ),
+                "unsupported": unsupported_categories,
+            }
+
+        if result == unknown:
             return {
                 "verified": False,
                 "status": "unverifiable",
                 "message": (
-                    f"UNVERIFIABLE: None of the provided clause categories are modeled by "
-                    f"ContradictionGuard. Supported categories: "
-                    f"{', '.join(sorted(SUPPORTED_CATEGORIES))}. "
-                    f"Received unsupported categories: {', '.join(unsupported_categories)}. "
-                    f"Cannot prove consistency for inputs that are not modeled."
+                    f"UNVERIFIABLE: Z3 returned unknown for the provided constraints "
+                    f"(e.g. timeout or excessive complexity). "
+                    f"Cannot determine consistency.{coverage_note}"
                 ),
                 "unsupported": unsupported_categories,
             }
 
-        # Build Z3 model for supported clauses only
-        s = Solver()
-        contract_duration_months = Int("contract_duration_months")
-        max_liability_usd = Int("max_liability_usd")
-
-        # Physical feasibility constraints
-        s.add(contract_duration_months >= 0)
-        s.add(max_liability_usd >= 0)
-
-        duration_clauses = [c for c in supported if c.category.upper() == "DURATION"]
-        liability_clauses = [c for c in supported if c.category.upper() == "LIABILITY"]
-
-        for c in duration_clauses:
-            text_lower = c.text.lower()
-            if "exactly" in text_lower:
-                s.add(contract_duration_months == c.value)
-            elif "minimum" in text_lower or "at least" in text_lower:
-                s.add(contract_duration_months >= c.value)
-            elif "maximum" in text_lower or "up to" in text_lower:
-                s.add(contract_duration_months <= c.value)
-            # Clauses that don't match any keyword are not silently ignored —
-            # they remain as candidates but generate no constraint.
-            # This is acceptable: the clause was recognized as DURATION but
-            # its keyword pattern is not modeled. Logged in partial_coverage.
-
-        for c in liability_clauses:
-            text_lower = c.text.lower()
-            if "capped" in text_lower or "max" in text_lower or "cap" in text_lower:
-                s.add(max_liability_usd <= c.value)
-            elif (
-                "penalty" in text_lower
-                or "fixed" in text_lower
-                or "minimum" in text_lower
-            ):
-                s.add(max_liability_usd >= c.value)
-
-        # Check satisfiability
-        result = s.check()
-
-        # Determine coverage status
-        has_unsupported = bool(unsupported)
-        coverage_note = ""
-        if has_unsupported:
-            coverage_note = (
-                f" NOTE: {len(unsupported)} clause(s) with unsupported "
-                f"categories ({', '.join(unsupported_categories)}) were excluded from "
-                f"the Z3 model. This result covers only the DURATION/LIABILITY subset."
-            )
-
-        if result == sat:
-            status = "partial_coverage" if has_unsupported else "consistent"
-            return {
-                "verified": True,
-                "status": status,
-                "message": (
-                    f"✅ CONSISTENT (modeled clauses): The DURATION and LIABILITY "
-                    f"clauses are logically satisfiable.{coverage_note}"
-                ),
-                "unsupported": unsupported_categories,
-            }
-        else:
-            return {
-                "verified": False,
-                "status": "contradiction",
-                "message": (
-                    f"❌ CONTRADICTION: The DURATION/LIABILITY clauses are mutually "
-                    f"exclusive (e.g., penalty > liability cap, or min term > max duration). "
-                    f"{coverage_note}"
-                ),
-                "unsupported": unsupported_categories,
-            }
+        # result == unsat → contradiction
+        return {
+            "verified": False,
+            "status": "contradiction",
+            "message": (
+                f"❌ CONTRADICTION: The DURATION/LIABILITY clauses are mutually "
+                f"exclusive (e.g., penalty > liability cap, or min term > max "
+                f"duration).{coverage_note}"
+            ),
+            "unsupported": unsupported_categories,
+        }

--- a/qwed_legal/guards/contradiction_guard.py
+++ b/qwed_legal/guards/contradiction_guard.py
@@ -1,76 +1,158 @@
-from z3 import Solver, Int, sat
+"""
+ContradictionGuard: Detect logical contradictions in contract clauses using Z3.
+
+Fail-closed design:
+  - Only DURATION and LIABILITY categories are modeled.
+  - Clauses with unsupported categories are not silently ignored.
+  - If NO clauses are translatable, returns UNVERIFIABLE instead of a false SAT.
+  - If SOME clauses are untranslatable, returns a partial-coverage warning.
+"""
+
+from dataclasses import dataclass, field
 from typing import List
-from dataclasses import dataclass
+
+from z3 import Int, Solver, sat
+
 
 @dataclass
 class Clause:
-    id: str
+    """A single contract clause with a category and numeric value."""
+
     text: str
-    category: str  # TERMINATION, DURATION, LIABILITY
-    value: int     # Normalized value (e.g. days, dollars)
+    category: str  # DURATION, LIABILITY — supported. All others: UNVERIFIABLE.
+    value: int
+    id: str = field(default="")  # optional identifier
+
+
+# Categories that ContradictionGuard can translate into Z3 constraints.
+SUPPORTED_CATEGORIES = frozenset({"DURATION", "LIABILITY"})
+
 
 class ContradictionGuard:
     """
-    Verifies Logical Consistency of Legal Contracts using Z3.
-    Detects contradictions like:
-    - "Term is 12 months" VS "Terminable at will after 2 years" (Impossible time travel)
-    - "Liability capped at $10k" VS "Minimum penalty $50k"
+    Detects logical contradictions in contract clauses using Z3.
+
+    Supported categories: DURATION, LIABILITY.
+
+    Fail-closed:
+    - Clauses with unsupported categories (PAYMENT, PENALTY, etc.) are not
+      silently ignored — they trigger an UNVERIFIABLE result.
+    - If no supported clauses are present, returns UNVERIFIABLE instead of
+      a false SAT (absence of constraints does not mean consistency).
+    - If some clauses are unsupported, returns PARTIAL_COVERAGE with a warning.
     """
-    
+
     def verify_consistency(self, clauses: List[Clause]) -> dict:
         """
-        Translates legal clauses into Z3 constraints and checks for SAT.
-        """
-        s = Solver()
-        
-        # We model key variables that clauses constrain
-        contract_duration_months = Int('contract_duration_months')
-        max_liability_usd = Int('max_liability_usd')
-        notice_period_days = Int('notice_period_days')
-        
-        # Basic physical constraints (No negative time/money)
-        s.add(contract_duration_months >= 0)
-        s.add(max_liability_usd >= 0)
-        s.add(notice_period_days >= 0)
-        
-        term_clauses = [c for c in clauses if c.category == "DURATION"]
-        liability_clauses = [c for c in clauses if c.category == "LIABILITY"]
-        
-        # --- Logic Translation ---
-        # Note: Real-world version would use an LLM or Parser to convert Text -> Z3
-        # Here we assume the parser has extracted the 'value' and 'category'.
-        
-        for c in term_clauses:
-            # Example: "Duration shall be exactly 12 months"
-            # Example: "Duration must be at least 24 months"
-            if "exactly" in c.text.lower():
-                s.add(contract_duration_months == c.value)
-            elif "minimum" in c.text.lower() or "at least" in c.text.lower():
-                s.add(contract_duration_months >= c.value)
-            elif "maximum" in c.text.lower() or "up to" in c.text.lower():
-                s.add(contract_duration_months <= c.value)
-                
-        for c in liability_clauses:
-            # Example: "Liability capped at 5000"
-            if "capped" in c.text.lower() or "max" in c.text.lower():
-                s.add(max_liability_usd <= c.value)
-            # Example: "Penalty shall be 10000"
-            elif "penalty" in c.text.lower() or "fixed" in c.text.lower():
-                # A penalty implies liability is AT LEAST this much if breach happens
-                # If penalty > Cap, then UNSAT.
-                s.add(max_liability_usd >= c.value)
+        Translate supported legal clauses into Z3 constraints and check for SAT.
 
-        # Check Consistency
-        if s.check() == sat:
-            return {
-                "verified": True,
-                "message": "✅ Contract logic is consistent."
-            }
-        else:
-            # Find the core conflict (Simplified/Mocked diagnosis)
-            # Real Z3 can use unsat_core()
-            
+        Returns a dict with keys:
+          verified     (bool)
+          status       (str)  — one of: consistent, contradiction, unverifiable, partial_coverage
+          message      (str)
+          unsupported  (list) — categories not modeled by this guard
+        """
+        if not clauses:
             return {
                 "verified": False,
-                "message": "❌ LOGIC CONTRADICTION: Clauses are mutually exclusive. (e.g. Penalty > Liability Cap, or Min Term > Max Duration). Check Z3 trace."
+                "status": "unverifiable",
+                "message": (
+                    "UNVERIFIABLE: No clauses provided. "
+                    "An empty clause list cannot be proven consistent."
+                ),
+                "unsupported": [],
+            }
+
+        # Partition clauses into supported and unsupported
+        supported = [c for c in clauses if c.category.upper() in SUPPORTED_CATEGORIES]
+        unsupported = [
+            c for c in clauses if c.category.upper() not in SUPPORTED_CATEGORIES
+        ]
+        unsupported_categories = sorted({c.category for c in unsupported})
+
+        # Fail closed: if there are NO supported clauses we cannot prove anything
+        if not supported:
+            return {
+                "verified": False,
+                "status": "unverifiable",
+                "message": (
+                    f"UNVERIFIABLE: None of the provided clause categories are modeled by "
+                    f"ContradictionGuard. Supported categories: "
+                    f"{', '.join(sorted(SUPPORTED_CATEGORIES))}. "
+                    f"Received unsupported categories: {', '.join(unsupported_categories)}. "
+                    f"Cannot prove consistency for inputs that are not modeled."
+                ),
+                "unsupported": unsupported_categories,
+            }
+
+        # Build Z3 model for supported clauses only
+        s = Solver()
+        contract_duration_months = Int("contract_duration_months")
+        max_liability_usd = Int("max_liability_usd")
+
+        # Physical feasibility constraints
+        s.add(contract_duration_months >= 0)
+        s.add(max_liability_usd >= 0)
+
+        duration_clauses = [c for c in supported if c.category.upper() == "DURATION"]
+        liability_clauses = [c for c in supported if c.category.upper() == "LIABILITY"]
+
+        for c in duration_clauses:
+            text_lower = c.text.lower()
+            if "exactly" in text_lower:
+                s.add(contract_duration_months == c.value)
+            elif "minimum" in text_lower or "at least" in text_lower:
+                s.add(contract_duration_months >= c.value)
+            elif "maximum" in text_lower or "up to" in text_lower:
+                s.add(contract_duration_months <= c.value)
+            # Clauses that don't match any keyword are not silently ignored —
+            # they remain as candidates but generate no constraint.
+            # This is acceptable: the clause was recognized as DURATION but
+            # its keyword pattern is not modeled. Logged in partial_coverage.
+
+        for c in liability_clauses:
+            text_lower = c.text.lower()
+            if "capped" in text_lower or "max" in text_lower or "cap" in text_lower:
+                s.add(max_liability_usd <= c.value)
+            elif (
+                "penalty" in text_lower
+                or "fixed" in text_lower
+                or "minimum" in text_lower
+            ):
+                s.add(max_liability_usd >= c.value)
+
+        # Check satisfiability
+        result = s.check()
+
+        # Determine coverage status
+        has_unsupported = bool(unsupported)
+        coverage_note = ""
+        if has_unsupported:
+            coverage_note = (
+                f" NOTE: {len(unsupported)} clause(s) with unsupported "
+                f"categories ({', '.join(unsupported_categories)}) were excluded from "
+                f"the Z3 model. This result covers only the DURATION/LIABILITY subset."
+            )
+
+        if result == sat:
+            status = "partial_coverage" if has_unsupported else "consistent"
+            return {
+                "verified": True,
+                "status": status,
+                "message": (
+                    f"✅ CONSISTENT (modeled clauses): The DURATION and LIABILITY "
+                    f"clauses are logically satisfiable.{coverage_note}"
+                ),
+                "unsupported": unsupported_categories,
+            }
+        else:
+            return {
+                "verified": False,
+                "status": "contradiction",
+                "message": (
+                    f"❌ CONTRADICTION: The DURATION/LIABILITY clauses are mutually "
+                    f"exclusive (e.g., penalty > liability cap, or min term > max duration). "
+                    f"{coverage_note}"
+                ),
+                "unsupported": unsupported_categories,
             }

--- a/qwed_legal/guards/jurisdiction_guard.py
+++ b/qwed_legal/guards/jurisdiction_guard.py
@@ -246,7 +246,6 @@ class JurisdictionGuard:
         parties_countries: List[str],
         governing_law: str,
         forum: Optional[str] = None,
-        jurisdiction_type: JurisdictionType = JurisdictionType.EXCLUSIVE,
     ) -> JurisdictionResult:
         """
         Verify choice of law and forum selection clause.
@@ -355,7 +354,6 @@ class JurisdictionGuard:
         self,
         forum: str,
         contract_value: Optional[float] = None,
-        parties_countries: Optional[List[str]] = None,
     ) -> JurisdictionResult:
         """
         Verify forum selection clause validity.

--- a/qwed_legal/guards/jurisdiction_guard.py
+++ b/qwed_legal/guards/jurisdiction_guard.py
@@ -11,6 +11,7 @@ from enum import Enum
 
 class JurisdictionType(Enum):
     """Types of jurisdiction clauses."""
+
     EXCLUSIVE = "exclusive"
     NON_EXCLUSIVE = "non_exclusive"
     HYBRID = "hybrid"
@@ -19,6 +20,7 @@ class JurisdictionType(Enum):
 @dataclass
 class JurisdictionResult:
     """Result of jurisdiction verification."""
+
     verified: bool
     conflicts: List[str] = field(default_factory=list)
     warnings: List[str] = field(default_factory=list)
@@ -30,12 +32,12 @@ class JurisdictionResult:
 class JurisdictionGuard:
     """
     Verify jurisdiction-related claims in legal contracts.
-    
+
     Catches common LLM errors like:
     - Mismatched governing law and forum selection
     - Invalid jurisdiction combinations
     - Cross-border regulation conflicts
-    
+
     Example:
         >>> guard = JurisdictionGuard()
         >>> result = guard.verify_choice_of_law(
@@ -45,63 +47,192 @@ class JurisdictionGuard:
         ... )
         >>> print(result.conflicts)  # Potential mismatch warning
     """
-    
+
     # Common law jurisdictions
     COMMON_LAW_JURISDICTIONS: Set[str] = {
-        "US", "UK", "GB", "CA", "AU", "NZ", "IE", "SG", "HK", "IN"
+        "US",
+        "UK",
+        "GB",
+        "CA",
+        "AU",
+        "NZ",
+        "IE",
+        "SG",
+        "HK",
+        "IN",
     }
-    
+
     # Civil law jurisdictions
     CIVIL_LAW_JURISDICTIONS: Set[str] = {
-        "DE", "FR", "IT", "ES", "NL", "BE", "AT", "CH", "JP", "KR", "BR", "MX"
+        "DE",
+        "FR",
+        "IT",
+        "ES",
+        "NL",
+        "BE",
+        "AT",
+        "CH",
+        "JP",
+        "KR",
+        "BR",
+        "MX",
     }
-    
+
     # US state abbreviations for forum selection
     US_STATES: Set[str] = {
-        "AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DE", "FL", "GA",
-        "HI", "ID", "IL", "IN", "IA", "KS", "KY", "LA", "ME", "MD",
-        "MA", "MI", "MN", "MS", "MO", "MT", "NE", "NV", "NH", "NJ",
-        "NM", "NY", "NC", "ND", "OH", "OK", "OR", "PA", "RI", "SC",
-        "SD", "TN", "TX", "UT", "VT", "VA", "WA", "WV", "WI", "WY", "DC"
+        "AL",
+        "AK",
+        "AZ",
+        "AR",
+        "CA",
+        "CO",
+        "CT",
+        "DE",
+        "FL",
+        "GA",
+        "HI",
+        "ID",
+        "IL",
+        "IN",
+        "IA",
+        "KS",
+        "KY",
+        "LA",
+        "ME",
+        "MD",
+        "MA",
+        "MI",
+        "MN",
+        "MS",
+        "MO",
+        "MT",
+        "NE",
+        "NV",
+        "NH",
+        "NJ",
+        "NM",
+        "NY",
+        "NC",
+        "ND",
+        "OH",
+        "OK",
+        "OR",
+        "PA",
+        "RI",
+        "SC",
+        "SD",
+        "TN",
+        "TX",
+        "UT",
+        "VT",
+        "VA",
+        "WA",
+        "WV",
+        "WI",
+        "WY",
+        "DC",
     }
-    
+
     # Popular corporate law states
     CORPORATE_LAW_STATES: Set[str] = {"DE", "NV", "WY", "NY", "CA"}
-    
+
     # Recognized international conventions
     INTERNATIONAL_CONVENTIONS: Dict[str, Set[str]] = {
         "CISG": {  # UN Convention on International Sale of Goods
-            "US", "DE", "FR", "IT", "ES", "NL", "AT", "CH", "CN", "JP", "AU", "CA"
+            "US",
+            "DE",
+            "FR",
+            "IT",
+            "ES",
+            "NL",
+            "AT",
+            "CH",
+            "CN",
+            "JP",
+            "AU",
+            "CA",
         },
         "HAGUE_CHOICE": {  # Hague Choice of Court Convention
-            "EU", "UK", "SG", "MX", "ME", "UA"
+            "EU",
+            "UK",
+            "SG",
+            "MX",
+            "ME",
+            "UA",
         },
         "NEW_YORK_CONVENTION": {  # Recognition of Arbitral Awards
-            "US", "UK", "DE", "FR", "CN", "JP", "IN", "AU", "BR", "CA"
-        }
+            "US",
+            "UK",
+            "DE",
+            "FR",
+            "CN",
+            "JP",
+            "IN",
+            "AU",
+            "BR",
+            "CA",
+        },
     }
-    
+
     # US State full names to abbreviations mapping
     US_STATE_NAMES: Dict[str, str] = {
-        "ALABAMA": "AL", "ALASKA": "AK", "ARIZONA": "AZ", "ARKANSAS": "AR",
-        "CALIFORNIA": "CA", "COLORADO": "CO", "CONNECTICUT": "CT", "DELAWARE": "DE",
-        "FLORIDA": "FL", "GEORGIA": "GA", "HAWAII": "HI", "IDAHO": "ID",
-        "ILLINOIS": "IL", "INDIANA": "IN", "IOWA": "IA", "KANSAS": "KS",
-        "KENTUCKY": "KY", "LOUISIANA": "LA", "MAINE": "ME", "MARYLAND": "MD",
-        "MASSACHUSETTS": "MA", "MICHIGAN": "MI", "MINNESOTA": "MN", "MISSISSIPPI": "MS",
-        "MISSOURI": "MO", "MONTANA": "MT", "NEBRASKA": "NE", "NEVADA": "NV",
-        "NEW HAMPSHIRE": "NH", "NEW JERSEY": "NJ", "NEW MEXICO": "NM", "NEW YORK": "NY",
-        "NORTH CAROLINA": "NC", "NORTH DAKOTA": "ND", "OHIO": "OH", "OKLAHOMA": "OK",
-        "OREGON": "OR", "PENNSYLVANIA": "PA", "RHODE ISLAND": "RI", "SOUTH CAROLINA": "SC",
-        "SOUTH DAKOTA": "SD", "TENNESSEE": "TN", "TEXAS": "TX", "UTAH": "UT",
-        "VERMONT": "VT", "VIRGINIA": "VA", "WASHINGTON": "WA", "WEST VIRGINIA": "WV",
-        "WISCONSIN": "WI", "WYOMING": "WY", "DISTRICT OF COLUMBIA": "DC"
+        "ALABAMA": "AL",
+        "ALASKA": "AK",
+        "ARIZONA": "AZ",
+        "ARKANSAS": "AR",
+        "CALIFORNIA": "CA",
+        "COLORADO": "CO",
+        "CONNECTICUT": "CT",
+        "DELAWARE": "DE",
+        "FLORIDA": "FL",
+        "GEORGIA": "GA",
+        "HAWAII": "HI",
+        "IDAHO": "ID",
+        "ILLINOIS": "IL",
+        "INDIANA": "IN",
+        "IOWA": "IA",
+        "KANSAS": "KS",
+        "KENTUCKY": "KY",
+        "LOUISIANA": "LA",
+        "MAINE": "ME",
+        "MARYLAND": "MD",
+        "MASSACHUSETTS": "MA",
+        "MICHIGAN": "MI",
+        "MINNESOTA": "MN",
+        "MISSISSIPPI": "MS",
+        "MISSOURI": "MO",
+        "MONTANA": "MT",
+        "NEBRASKA": "NE",
+        "NEVADA": "NV",
+        "NEW HAMPSHIRE": "NH",
+        "NEW JERSEY": "NJ",
+        "NEW MEXICO": "NM",
+        "NEW YORK": "NY",
+        "NORTH CAROLINA": "NC",
+        "NORTH DAKOTA": "ND",
+        "OHIO": "OH",
+        "OKLAHOMA": "OK",
+        "OREGON": "OR",
+        "PENNSYLVANIA": "PA",
+        "RHODE ISLAND": "RI",
+        "SOUTH CAROLINA": "SC",
+        "SOUTH DAKOTA": "SD",
+        "TENNESSEE": "TN",
+        "TEXAS": "TX",
+        "UTAH": "UT",
+        "VERMONT": "VT",
+        "VIRGINIA": "VA",
+        "WASHINGTON": "WA",
+        "WEST VIRGINIA": "WV",
+        "WISCONSIN": "WI",
+        "WYOMING": "WY",
+        "DISTRICT OF COLUMBIA": "DC",
     }
-    
+
     def __init__(self):
         """Initialize JurisdictionGuard."""
         pass
-    
+
     def _normalize_jurisdiction(self, jurisdiction: str) -> str:
         """Normalize jurisdiction to standard form (abbreviation for US states)."""
         upper = jurisdiction.upper().strip()
@@ -109,125 +240,142 @@ class JurisdictionGuard:
         if upper in self.US_STATE_NAMES:
             return self.US_STATE_NAMES[upper]
         return upper
-    
+
     def verify_choice_of_law(
         self,
         parties_countries: List[str],
         governing_law: str,
         forum: Optional[str] = None,
-        jurisdiction_type: JurisdictionType = JurisdictionType.EXCLUSIVE
+        jurisdiction_type: JurisdictionType = JurisdictionType.EXCLUSIVE,
     ) -> JurisdictionResult:
         """
         Verify choice of law and forum selection clause.
-        
+
         Args:
             parties_countries: List of country codes for contract parties
             governing_law: The stated governing law (country or state)
             forum: The stated forum/venue (optional)
             jurisdiction_type: Type of jurisdiction clause
-            
+
         Returns:
             JurisdictionResult with verification status and any conflicts
         """
         conflicts = []
         warnings = []
-        
+
         # Normalize inputs (convert full state names to abbreviations)
         governing_law_upper = self._normalize_jurisdiction(governing_law)
         parties_upper = [p.upper().strip() for p in parties_countries]
         forum_upper = self._normalize_jurisdiction(forum) if forum else None
-        
+
         # Check 1: Is governing law a recognized jurisdiction?
         if not self._is_valid_jurisdiction(governing_law_upper):
             conflicts.append(
                 f"Unrecognized governing law jurisdiction: '{governing_law}'"
             )
-        
+
         # Check 2: Cross-border legal system conflicts
+        # Unknown party country codes are not silently skipped —
+        # they are flagged so downstream consumers know coverage is partial.
         party_legal_systems = set()
+        unknown_party_countries = []
         for country in parties_upper:
             if country in self.COMMON_LAW_JURISDICTIONS:
                 party_legal_systems.add("COMMON_LAW")
             elif country in self.CIVIL_LAW_JURISDICTIONS:
                 party_legal_systems.add("CIVIL_LAW")
-        
+            else:
+                unknown_party_countries.append(country)
+
+        if unknown_party_countries:
+            warnings.append(
+                f"Unrecognized party country code(s): {', '.join(unknown_party_countries)}. "
+                f"Legal system classification (Common Law / Civil Law) is incomplete. "
+                f"Cross-border conflict analysis may be inaccurate."
+            )
+
         if len(party_legal_systems) > 1:
             warnings.append(
                 "Cross-border contract with parties from different legal systems "
                 "(Common Law and Civil Law). Consider CISG applicability."
             )
-        
+
         # Check 3: Forum vs governing law mismatch
         if forum_upper and governing_law_upper:
-            if self._is_us_state(governing_law_upper) and not self._is_us_jurisdiction(forum_upper):
+            if self._is_us_state(governing_law_upper) and not self._is_us_jurisdiction(
+                forum_upper
+            ):
                 conflicts.append(
                     f"Governing law '{governing_law}' (US state) but forum '{forum}' is non-US. "
                     "This may create enforcement issues."
                 )
             elif self._is_us_state(forum_upper) and not (
-                self._is_us_jurisdiction(governing_law_upper) or governing_law_upper in ["US", "NY", "CA", "DE"]
+                self._is_us_jurisdiction(governing_law_upper)
+                or governing_law_upper in ["US", "NY", "CA", "DE"]
             ):
                 conflicts.append(
                     f"Forum '{forum}' (US state) but governing law '{governing_law}' is non-US. "
                     "Consider alignment for enforceability."
                 )
-        
+
         # Check 4: CISG applicability warning
         us_party = any(c in ["US"] or c in self.US_STATES for c in parties_upper)
-        foreign_party = any(c not in ["US"] and c not in self.US_STATES for c in parties_upper)
+        foreign_party = any(
+            c not in ["US"] and c not in self.US_STATES for c in parties_upper
+        )
         if us_party and foreign_party:
             warnings.append(
                 "International sale of goods may be subject to CISG unless expressly excluded."
             )
-        
+
         # Check 5: Neutral jurisdiction suggestion
         if len(parties_upper) >= 2 and governing_law_upper in parties_upper:
             warnings.append(
                 f"Governing law '{governing_law}' favors one party's home jurisdiction. "
                 "Consider a neutral jurisdiction for balance."
             )
-        
+
         verified = len(conflicts) == 0
-        
+
         if verified:
             message = "✅ VERIFIED: Jurisdiction clause appears consistent."
         else:
             message = f"❌ CONFLICTS DETECTED: {len(conflicts)} issue(s) found."
-        
+
         return JurisdictionResult(
             verified=verified,
             conflicts=conflicts,
             warnings=warnings,
             governing_law=governing_law,
             forum=forum,
-            message=message
+            message=message,
         )
-    
+
     def verify_forum_selection(
         self,
         forum: str,
         contract_value: Optional[float] = None,
-        parties_countries: Optional[List[str]] = None
+        parties_countries: Optional[List[str]] = None,
     ) -> JurisdictionResult:
         """
         Verify forum selection clause validity.
-        
+
         Args:
             forum: The stated forum/venue
             contract_value: Optional contract value for threshold checks
             parties_countries: List of party countries
-            
+
         Returns:
             JurisdictionResult with verification status
         """
         conflicts = []
         warnings = []
         forum_upper = self._normalize_jurisdiction(forum)
-        
+
         # Validate forum
         if not self._is_valid_jurisdiction(forum_upper):
             conflicts.append(f"Unrecognized forum: '{forum}'")
-        
+
         # Check for common federal court thresholds
         if contract_value and forum_upper in self.US_STATES:
             if contract_value < 75000:
@@ -235,80 +383,82 @@ class JurisdictionGuard:
                     f"Contract value ${contract_value:,.0f} may not meet diversity "
                     "jurisdiction threshold ($75,000) for US federal court."
                 )
-        
+
         verified = len(conflicts) == 0
-        message = "✅ VERIFIED: Forum selection is valid." if verified else f"❌ {conflicts[0]}"
-        
+        message = (
+            "✅ VERIFIED: Forum selection is valid."
+            if verified
+            else f"❌ {conflicts[0]}"
+        )
+
         return JurisdictionResult(
             verified=verified,
             conflicts=conflicts,
             warnings=warnings,
             forum=forum,
-            message=message
+            message=message,
         )
-    
+
     def check_convention_applicability(
-        self,
-        parties_countries: List[str],
-        convention: str
+        self, parties_countries: List[str], convention: str
     ) -> JurisdictionResult:
         """
         Check if an international convention applies.
-        
+
         Args:
             parties_countries: List of party country codes
             convention: Convention name (CISG, HAGUE_CHOICE, NEW_YORK_CONVENTION)
-            
+
         Returns:
             JurisdictionResult with applicability status
         """
         convention_upper = convention.upper().replace(" ", "_")
         parties_upper = [p.upper().strip() for p in parties_countries]
-        
+
         if convention_upper not in self.INTERNATIONAL_CONVENTIONS:
             return JurisdictionResult(
                 verified=False,
                 conflicts=[f"Unknown convention: '{convention}'"],
-                message=f"❌ Unknown convention: '{convention}'"
+                message=f"❌ Unknown convention: '{convention}'",
             )
-        
+
         member_countries = self.INTERNATIONAL_CONVENTIONS[convention_upper]
         all_members = all(c in member_countries for c in parties_upper)
         some_members = any(c in member_countries for c in parties_upper)
-        
+
         if all_members:
             return JurisdictionResult(
                 verified=True,
                 message=f"✅ {convention} applies - all parties are from member states.",
-                warnings=[]
+                warnings=[],
             )
         elif some_members:
             non_members = [c for c in parties_upper if c not in member_countries]
             return JurisdictionResult(
                 verified=False,
                 warnings=[f"Not all parties are {convention} members: {non_members}"],
-                message=f"⚠️ {convention} may not apply to all parties."
+                message=f"⚠️ {convention} may not apply to all parties.",
             )
         else:
             return JurisdictionResult(
                 verified=False,
                 conflicts=[f"No parties are {convention} member states."],
-                message=f"❌ {convention} does not apply."
+                message=f"❌ {convention} does not apply.",
             )
-    
+
     def _is_valid_jurisdiction(self, jurisdiction: str) -> bool:
         """Check if a jurisdiction is recognized."""
         return (
-            jurisdiction in self.COMMON_LAW_JURISDICTIONS or
-            jurisdiction in self.CIVIL_LAW_JURISDICTIONS or
-            jurisdiction in self.US_STATES or
-            jurisdiction in {"EU", "UK", "ENGLAND", "SCOTLAND", "WALES"}
+            jurisdiction in self.COMMON_LAW_JURISDICTIONS
+            or jurisdiction in self.CIVIL_LAW_JURISDICTIONS
+            or jurisdiction in self.US_STATES
+            or jurisdiction in {"EU", "UK", "ENGLAND", "SCOTLAND", "WALES"}
         )
-    
+
     def _is_us_state(self, jurisdiction: str) -> bool:
         """Check if jurisdiction is a US state."""
         return jurisdiction in self.US_STATES
-    
+
     def _is_us_jurisdiction(self, jurisdiction: str) -> bool:
         """Check if jurisdiction is US-related."""
         return jurisdiction in self.US_STATES or jurisdiction == "US"

--- a/tests/test_fail_closed_guards.py
+++ b/tests/test_fail_closed_guards.py
@@ -1,0 +1,362 @@
+"""
+Tests for issue #20: fail-closed enforcement across legal guards.
+
+Covers:
+- ContradictionGuard: unsupported categories → UNVERIFIABLE
+- ContradictionGuard: empty input → UNVERIFIABLE
+- ContradictionGuard: mixed supported+unsupported → partial_coverage warning
+- ContradictionGuard: supported categories still work correctly
+- ClauseGuard: no extractable propositions → HEURISTIC_PASS caveat, not VERIFIED
+- ClauseGuard: known conflicts still detected
+- JurisdictionGuard: unknown party countries → warning in result
+"""
+
+from qwed_legal.guards.contradiction_guard import Clause, ContradictionGuard
+from qwed_legal.guards.clause_guard import ClauseGuard
+from qwed_legal.guards.jurisdiction_guard import JurisdictionGuard
+
+
+# ─── ContradictionGuard ────────────────────────────────────────────────────────
+
+
+class TestContradictionGuardFailClosed:
+    """Issue #20: ContradictionGuard must not silently ignore unsupported categories."""
+
+    def setup_method(self):
+        self.guard = ContradictionGuard()
+
+    # Empty input
+
+    def test_empty_clauses_unverifiable(self):
+        """Empty list must return UNVERIFIABLE — no constraints ≠ consistent."""
+        result = self.guard.verify_consistency([])
+        assert result["verified"] is False
+        assert result["status"] == "unverifiable"
+        assert "UNVERIFIABLE" in result["message"]
+
+    # Unsupported categories
+
+    def test_payment_category_unverifiable(self):
+        """PAYMENT clauses are not modeled — must return UNVERIFIABLE."""
+        result = self.guard.verify_consistency(
+            [
+                Clause(text="Payment due in 15 days.", category="PAYMENT", value=15),
+                Clause(text="Payment due in 60 days.", category="PAYMENT", value=60),
+            ]
+        )
+        assert result["verified"] is False
+        assert result["status"] == "unverifiable"
+        assert "UNVERIFIABLE" in result["message"]
+        assert "PAYMENT" in result["message"]
+        assert "PAYMENT" in result["unsupported"]
+
+    def test_penalty_category_unverifiable(self):
+        """PENALTY clauses are not modeled — must return UNVERIFIABLE."""
+        result = self.guard.verify_consistency(
+            [
+                Clause(
+                    text="Penalty of $5000 for late delivery.",
+                    category="PENALTY",
+                    value=5000,
+                ),
+            ]
+        )
+        assert result["verified"] is False
+        assert result["status"] == "unverifiable"
+        assert "PENALTY" in result["unsupported"]
+
+    def test_novel_category_unverifiable(self):
+        """Any category not in {DURATION, LIABILITY} must fail closed."""
+        result = self.guard.verify_consistency(
+            [
+                Clause(
+                    text="Confidential for 2 years.",
+                    category="CONFIDENTIALITY",
+                    value=24,
+                ),
+            ]
+        )
+        assert result["verified"] is False
+        assert result["status"] == "unverifiable"
+        assert "CONFIDENTIALITY" in result["unsupported"]
+
+    def test_entirely_unknown_categories_unverifiable(self):
+        """Mix of unsupported categories only → UNVERIFIABLE (not silently SAT)."""
+        result = self.guard.verify_consistency(
+            [
+                Clause(
+                    text="Pay invoice within 30 days.", category="PAYMENT", value=30
+                ),
+                Clause(
+                    text="Liquidated damages of $1000/day.",
+                    category="DAMAGES",
+                    value=1000,
+                ),
+                Clause(
+                    text="Govern by English law.", category="GOVERNING_LAW", value=0
+                ),
+            ]
+        )
+        assert result["verified"] is False
+        assert result["status"] == "unverifiable"
+        assert len(result["unsupported"]) > 0
+
+    # Partial coverage (some supported, some not)
+
+    def test_mixed_categories_partial_coverage(self):
+        """Mix of DURATION + PAYMENT → partial_coverage warning, not silent verification."""
+        result = self.guard.verify_consistency(
+            [
+                Clause(
+                    text="Contract duration exactly 12 months.",
+                    category="DURATION",
+                    value=12,
+                ),
+                Clause(text="Payment due in 30 days.", category="PAYMENT", value=30),
+            ]
+        )
+        # PAYMENT is unsupported — must be flagged
+        assert "PAYMENT" in result["unsupported"]
+        # If supported clause (DURATION) is satisfiable, result may be verified=True
+        # BUT must carry partial_coverage status, not "consistent"
+        if result["verified"]:
+            assert result["status"] == "partial_coverage"
+            assert (
+                "excluded" in result["message"].lower()
+                or "unsupported" in result["message"].lower()
+            )
+
+    # Supported categories still work
+
+    def test_duration_contradiction_detected(self):
+        """DURATION contradiction (min > max) must still be caught."""
+        result = self.guard.verify_consistency(
+            [
+                Clause(
+                    text="Contract duration minimum 24 months.",
+                    category="DURATION",
+                    value=24,
+                ),
+                Clause(
+                    text="Contract duration maximum 12 months.",
+                    category="DURATION",
+                    value=12,
+                ),
+            ]
+        )
+        assert result["verified"] is False
+        assert result["status"] == "contradiction"
+
+    def test_liability_contradiction_detected(self):
+        """LIABILITY contradiction (penalty > cap) must still be caught."""
+        result = self.guard.verify_consistency(
+            [
+                Clause(
+                    text="Liability capped at 5000.", category="LIABILITY", value=5000
+                ),
+                Clause(
+                    text="Penalty fixed at 10000.", category="LIABILITY", value=10000
+                ),
+            ]
+        )
+        assert result["verified"] is False
+        assert result["status"] == "contradiction"
+
+    def test_consistent_duration_clauses_pass(self):
+        """Non-contradictory DURATION clauses must return consistent."""
+        result = self.guard.verify_consistency(
+            [
+                Clause(
+                    text="Contract duration minimum 6 months.",
+                    category="DURATION",
+                    value=6,
+                ),
+                Clause(
+                    text="Contract duration maximum 24 months.",
+                    category="DURATION",
+                    value=24,
+                ),
+            ]
+        )
+        assert result["verified"] is True
+        assert result["status"] == "consistent"
+        assert result["unsupported"] == []
+
+    def test_consistent_liability_clauses_pass(self):
+        """Non-contradictory LIABILITY clauses must return consistent."""
+        result = self.guard.verify_consistency(
+            [
+                Clause(
+                    text="Liability capped at 50000.", category="LIABILITY", value=50000
+                ),
+                Clause(
+                    text="Penalty fixed at 10000.", category="LIABILITY", value=10000
+                ),
+            ]
+        )
+        assert result["verified"] is True
+        assert result["status"] == "consistent"
+
+    def test_unsupported_key_in_result(self):
+        """Result must always include 'unsupported' key listing skipped categories."""
+        result = self.guard.verify_consistency(
+            [
+                Clause(
+                    text="Duration exactly 12 months.", category="DURATION", value=12
+                ),
+            ]
+        )
+        assert "unsupported" in result
+        assert isinstance(result["unsupported"], list)
+
+    def test_status_key_always_present(self):
+        """Result must always include a 'status' field."""
+        result = self.guard.verify_consistency(
+            [
+                Clause(
+                    text="Duration exactly 12 months.", category="DURATION", value=12
+                ),
+            ]
+        )
+        assert "status" in result
+        assert result["status"] in {
+            "consistent",
+            "contradiction",
+            "unverifiable",
+            "partial_coverage",
+        }
+
+
+# ─── ClauseGuard ──────────────────────────────────────────────────────────────
+
+
+class TestClauseGuardFailClosed:
+    """Issue #20: ClauseGuard must not claim VERIFIED when coverage is zero."""
+
+    def setup_method(self):
+        self.guard = ClauseGuard()
+
+    def test_unsupported_clause_type_is_not_verified(self):
+        """
+        Clauses with no extractable termination/notice/exclusivity propositions
+        must return HEURISTIC_PASS with a caveat, not 'VERIFIED'.
+        """
+        result = self.guard.check_consistency(
+            [
+                "Payment shall be made in USD.",
+                "Governing law shall be English law.",
+            ]
+        )
+        # Must NOT say "VERIFIED" — no propositions were extracted
+        assert (
+            "VERIFIED" not in result.message.upper()
+            or "HEURISTIC" in result.message.upper()
+        )
+        # Must indicate limited coverage
+        assert any(
+            kw in result.message.upper()
+            for kw in ["HEURISTIC", "LIMITED", "CANNOT", "COVERAGE"]
+        ), f"Expected coverage caveat in: {result.message}"
+
+    def test_known_termination_conflict_still_detected(self):
+        """Known conflicts must still be detected after the fix."""
+        result = self.guard.check_consistency(
+            [
+                "Seller may terminate with 30 days notice.",
+                "Neither party may terminate before 90 days.",
+            ]
+        )
+        assert result.consistent is False
+
+    def test_single_clause_heuristic(self):
+        """Single clause returns consistent — cannot conflict with itself."""
+        result = self.guard.check_consistency(
+            ["Seller may terminate with 30 days notice."]
+        )
+        assert result.consistent is True
+
+    def test_payment_clauses_not_falsely_verified(self):
+        """Payment-only clauses must not return VERIFIED — guard has no payment model."""
+        result = self.guard.check_consistency(
+            [
+                "Payment due in 15 days.",
+                "Payment due in 60 days.",
+            ]
+        )
+        # No conflict detected (guard can't see it) but must not claim VERIFIED
+        assert "VERIFIED" not in result.message or "HEURISTIC" in result.message
+
+    def test_heuristic_pass_message_present_for_recognised_clauses(self):
+        """Clauses with recognisable termination patterns get HEURISTIC_PASS message."""
+        result = self.guard.check_consistency(
+            [
+                "Seller may terminate with 30 days notice.",
+                "Buyer may terminate with 60 days notice.",
+            ]
+        )
+        assert result.consistent is True
+        assert "HEURISTIC" in result.message.upper()
+
+
+# ─── JurisdictionGuard ────────────────────────────────────────────────────────
+
+
+class TestJurisdictionGuardFailClosed:
+    """Issue #20: JurisdictionGuard must not silently skip unknown party countries."""
+
+    def setup_method(self):
+        self.guard = JurisdictionGuard()
+
+    def test_unknown_party_country_generates_warning(self):
+        """Unknown party country code must appear in warnings, not be silently skipped."""
+        result = self.guard.verify_choice_of_law(
+            parties_countries=["US", "UNKNOWN_COUNTRY_XYZ"],
+            governing_law="New York",
+        )
+        warning_text = " ".join(result.warnings)
+        assert "UNKNOWN_COUNTRY_XYZ" in warning_text or any(
+            "unrecognized" in w.lower() or "unknown" in w.lower()
+            for w in result.warnings
+        ), f"Expected unknown country warning. Warnings: {result.warnings}"
+
+    def test_known_party_countries_no_spurious_warning(self):
+        """Known countries must not trigger the unknown-country warning."""
+        result = self.guard.verify_choice_of_law(
+            parties_countries=["US", "GB"],
+            governing_law="New York",
+        )
+        unknown_warnings = [
+            w
+            for w in result.warnings
+            if "unrecognized" in w.lower() and ("US" in w or "GB" in w)
+        ]
+        assert len(unknown_warnings) == 0
+
+    def test_unknown_governing_law_is_conflict(self):
+        """Unknown governing law must add to conflicts (existing behaviour preserved)."""
+        result = self.guard.verify_choice_of_law(
+            parties_countries=["US"],
+            governing_law="Unknown Territory",
+        )
+        assert result.verified is False
+        assert len(result.conflicts) > 0
+
+    def test_known_governing_law_passes(self):
+        """Valid governing law with known parties must not produce conflicts."""
+        result = self.guard.verify_choice_of_law(
+            parties_countries=["US"],
+            governing_law="New York",
+        )
+        assert result.verified is True
+        assert len(result.conflicts) == 0
+
+    def test_all_unknown_parties_warns(self):
+        """All-unknown party countries must all appear in warnings."""
+        result = self.guard.verify_choice_of_law(
+            parties_countries=["ATLANTIS", "NARNIA"],
+            governing_law="New York",
+        )
+        warning_text = " ".join(result.warnings)
+        assert "ATLANTIS" in warning_text or any(
+            "unrecognized" in w.lower() for w in result.warnings
+        )

--- a/tests/test_fail_closed_guards.py
+++ b/tests/test_fail_closed_guards.py
@@ -283,8 +283,8 @@ class TestClauseGuardFailClosed:
                 "Payment due in 60 days.",
             ]
         )
-        # No conflict detected (guard can't see it) but must not claim VERIFIED
-        assert "VERIFIED" not in result.message or "HEURISTIC" in result.message
+        # Must carry the limited-coverage status
+        assert result.status == "heuristic_pass_limited"
 
     def test_heuristic_pass_message_present_for_recognised_clauses(self):
         """Clauses with recognisable termination patterns get HEURISTIC_PASS message."""

--- a/tests/test_guards.py
+++ b/tests/test_guards.py
@@ -5,25 +5,31 @@ from unittest.mock import patch
 import pytest
 from z3 import Int, unknown as z3_unknown
 
-from qwed_legal import LegalGuard, DeadlineGuard, LiabilityGuard, ClauseGuard, CitationGuard
+from qwed_legal import (
+    LegalGuard,
+    DeadlineGuard,
+    LiabilityGuard,
+    ClauseGuard,
+    CitationGuard,
+)
 
 
 class TestDeadlineGuard:
     """Test DeadlineGuard functionality."""
-    
+
     def test_calendar_days_correct(self):
         """Test correct calendar day calculation."""
         guard = DeadlineGuard()
         result = guard.verify("2026-01-15", "30 days", "2026-02-14")
         assert result.verified is True
-    
+
     def test_calendar_days_wrong(self):
         """Test incorrect calendar day calculation."""
         guard = DeadlineGuard()
         result = guard.verify("2026-01-15", "30 days", "2026-02-10")
         assert result.verified is False
         assert "mismatch" in result.message.lower()
-    
+
     def test_business_days(self):
         """Test business day calculation excludes weekends."""
         guard = DeadlineGuard()
@@ -31,20 +37,20 @@ class TestDeadlineGuard:
         result = guard.verify("2026-01-15", "30 business days", "2026-02-27")
         # Allow some tolerance for holidays (varies by year/region)
         assert result.difference_days <= 5
-    
+
     def test_leap_year(self):
         """Test leap year handling."""
         guard = DeadlineGuard()
         # Feb 28, 2024 (leap year) + 1 day = Feb 29
         result = guard.verify("2024-02-28", "1 day", "2024-02-29")
         assert result.verified is True
-    
+
     def test_weeks(self):
         """Test week calculations."""
         guard = DeadlineGuard()
         result = guard.verify("2026-01-15", "2 weeks", "2026-01-29")
         assert result.verified is True
-    
+
     def test_months(self):
         """Test month calculations."""
         guard = DeadlineGuard()
@@ -54,26 +60,26 @@ class TestDeadlineGuard:
 
 class TestLiabilityGuard:
     """Test LiabilityGuard functionality."""
-    
+
     def test_cap_correct(self):
         """Test correct liability cap calculation."""
         guard = LiabilityGuard()
         result = guard.verify_cap(5_000_000, 200, 10_000_000)
         assert result.verified is True
-    
+
     def test_cap_wrong(self):
         """Test incorrect liability cap calculation."""
         guard = LiabilityGuard()
         result = guard.verify_cap(5_000_000, 200, 15_000_000)
         assert result.verified is False
         assert "mismatch" in result.message.lower()
-    
+
     def test_cap_100_percent(self):
         """Test 100% liability cap."""
         guard = LiabilityGuard()
         result = guard.verify_cap(1_000_000, 100, 1_000_000)
         assert result.verified is True
-    
+
     def test_tiered_liability(self):
         """Test tiered liability calculation."""
         guard = LiabilityGuard()
@@ -84,13 +90,13 @@ class TestLiabilityGuard:
         # 1M * 100% + 500K * 50% = 1M + 250K = 1.25M
         result = guard.verify_tiered_liability(tiers, 1_250_000)
         assert result.verified is True
-    
+
     def test_indemnity_limit(self):
         """Test indemnity limit calculation (3x annual fee)."""
         guard = LiabilityGuard()
         result = guard.verify_indemnity_limit(100_000, 3, 300_000)
         assert result.verified is True
-    
+
     def test_indemnity_limit_wrong(self):
         """Test incorrect indemnity limit."""
         guard = LiabilityGuard()
@@ -100,71 +106,89 @@ class TestLiabilityGuard:
 
 class TestClauseGuard:
     """Test ClauseGuard functionality."""
-    
-    def test_consistent_clauses(self):
-        """Test clauses that don't conflict."""
+
+    def test_consistent_clauses_no_propositions(self):
+        """Clauses with no extractable propositions return limited-coverage result."""
         guard = ClauseGuard()
-        result = guard.check_consistency([
-            "Seller shall deliver goods within 30 days",
-            "Buyer shall pay upon receipt",
-        ])
-        assert result.consistent is True
-    
+        result = guard.check_consistency(
+            [
+                "Seller shall deliver goods within 30 days",
+                "Buyer shall pay upon receipt",
+            ]
+        )
+        # Zero propositions extracted — guard cannot confirm consistency
+        assert result.consistent is False
+        assert (
+            "HEURISTIC" in result.message.upper() or "LIMITED" in result.message.upper()
+        )
+
     def test_termination_conflict(self):
         """Test conflicting termination clauses."""
         guard = ClauseGuard()
-        result = guard.check_consistency([
-            "Seller may terminate with 30 days notice",
-            "Neither party may terminate before 90 days",
-        ])
+        result = guard.check_consistency(
+            [
+                "Seller may terminate with 30 days notice",
+                "Neither party may terminate before 90 days",
+            ]
+        )
         assert result.consistent is False
         assert len(result.conflicts) >= 1
-    
+
     def test_single_clause(self):
         """Test single clause (no conflict possible)."""
         guard = ClauseGuard()
-        result = guard.check_consistency([
-            "Payment due within 30 days",
-        ])
+        result = guard.check_consistency(
+            [
+                "Payment due within 30 days",
+            ]
+        )
         assert result.consistent is True
-    
+
     def test_permission_prohibition_conflict(self):
         """Test permission vs prohibition conflict."""
         guard = ClauseGuard()
-        result = guard.check_consistency([
-            "Buyer may terminate at any time",
-            "Buyer may not terminate this agreement",
-        ])
+        result = guard.check_consistency(
+            [
+                "Buyer may terminate at any time",
+                "Buyer may not terminate this agreement",
+            ]
+        )
         # Should detect conflict between permission and prohibition
         assert result.consistent is False or len(result.conflicts) >= 0
 
     def test_termination_conflict_detected_in_reverse_order(self):
         """Reverse ordering should still detect the termination/minimum-term conflict."""
         guard = ClauseGuard()
-        result = guard.check_consistency([
-            "Neither party may terminate before 90 days",
-            "Seller may terminate with 30 days notice",
-        ])
+        result = guard.check_consistency(
+            [
+                "Neither party may terminate before 90 days",
+                "Seller may terminate with 30 days notice",
+            ]
+        )
         assert result.consistent is False
         assert any("minimum term" in reason for _, _, reason in result.conflicts)
 
     def test_exclusivity_conflict_for_same_party(self):
         """Exclusive rights granted twice to the same modeled party should conflict."""
         guard = ClauseGuard()
-        result = guard.check_consistency([
-            "Seller has exclusive distribution rights in Region A.",
-            "Seller has exclusive distribution rights in Region B.",
-        ])
+        result = guard.check_consistency(
+            [
+                "Seller has exclusive distribution rights in Region A.",
+                "Seller has exclusive distribution rights in Region B.",
+            ]
+        )
         assert result.consistent is False
         assert any("exclusive rights" in reason for _, _, reason in result.conflicts)
 
     def test_verify_using_z3_rejects_raw_text_constraints(self):
         """Raw text constraints should fail closed instead of pretending to be proven."""
         guard = ClauseGuard()
-        result = guard.verify_using_z3([
-            "The agreement must last exactly 12 months.",
-            "The agreement must last exactly 24 months.",
-        ])
+        result = guard.verify_using_z3(
+            [
+                "The agreement must last exactly 12 months.",
+                "The agreement must last exactly 24 months.",
+            ]
+        )
         assert result.consistent is False
         assert "UNVERIFIABLE" in result.message
 
@@ -195,7 +219,9 @@ class TestClauseGuard:
         """Z3 unknown must not default to consistent."""
         guard = ClauseGuard()
         months = Int("months")
-        with patch("qwed_legal.guards.clause_guard.Solver.check", return_value=z3_unknown):
+        with patch(
+            "qwed_legal.guards.clause_guard.Solver.check", return_value=z3_unknown
+        ):
             result = guard.verify_using_z3([months >= 12])
         assert result.consistent is False
         assert "UNVERIFIABLE" in result.message
@@ -205,7 +231,9 @@ class TestClauseGuard:
         """Unexpected solver states must also fail closed."""
         guard = ClauseGuard()
         months = Int("months")
-        with patch("qwed_legal.guards.clause_guard.Solver.check", return_value="mystery"):
+        with patch(
+            "qwed_legal.guards.clause_guard.Solver.check", return_value="mystery"
+        ):
             result = guard.verify_using_z3([months >= 12])
         assert result.consistent is False
         assert "unsupported satisfiability state" in result.message.lower()
@@ -213,7 +241,7 @@ class TestClauseGuard:
 
 class TestCitationGuard:
     """Test CitationGuard functionality."""
-    
+
     def test_valid_supreme_court_citation(self):
         """Test valid Supreme Court citation."""
         guard = CitationGuard()
@@ -221,28 +249,28 @@ class TestCitationGuard:
         assert result.valid is True
         assert result.parsed_components.get("volume") == 347
         assert result.parsed_components.get("reporter") == "U.S."
-    
+
     def test_valid_federal_citation(self):
         """Test valid Federal Reporter citation."""
         guard = CitationGuard()
         result = guard.verify("Smith v. Jones, 123 F.3d 456 (2020)")
         assert result.valid is True
         assert result.parsed_components.get("reporter") == "F.3d"
-    
+
     def test_invalid_reporter(self):
         """Test citation with invalid reporter."""
         guard = CitationGuard()
         result = guard.verify("Fake v. Case, 999 X.Y.Z. 123 (2020)")
         assert result.valid is False
         assert any("Unknown reporter" in issue for issue in result.issues)
-    
+
     def test_missing_case_name(self):
         """Test citation without proper case name."""
         guard = CitationGuard()
         result = guard.verify("123 U.S. 456 (1990)")
         assert result.valid is False
         assert any("case name" in issue.lower() for issue in result.issues)
-    
+
     def test_batch_verification(self):
         """Test batch citation verification."""
         guard = CitationGuard()
@@ -254,7 +282,7 @@ class TestCitationGuard:
         assert result.total == 2
         assert result.valid == 1
         assert result.invalid == 1
-    
+
     def test_statute_citation(self):
         """Test statute citation verification."""
         guard = CitationGuard()
@@ -265,69 +293,75 @@ class TestCitationGuard:
 
 class TestLegalGuard:
     """Test the all-in-one LegalGuard."""
-    
+
     def test_verify_deadline(self):
         """Test LegalGuard.verify_deadline."""
         guard = LegalGuard()
         result = guard.verify_deadline("2026-01-15", "30 days", "2026-02-14")
         assert result.verified is True
-    
+
     def test_verify_liability_cap(self):
         """Test LegalGuard.verify_liability_cap."""
         guard = LegalGuard()
         result = guard.verify_liability_cap(5_000_000, 200, 10_000_000)
         assert result.verified is True
-    
+
     def test_check_clause_consistency(self):
         """Test LegalGuard.check_clause_consistency."""
         guard = LegalGuard()
-        result = guard.check_clause_consistency([
-            "Payment due in 30 days",
-            "Net 30 terms apply",
-        ])
-        assert result.consistent is True
+        result = guard.check_clause_consistency(
+            [
+                "Payment due in 30 days",
+                "Net 30 terms apply",
+            ]
+        )
+        # Payment/Net-30 clauses have no termination/exclusivity propositions
+        # Consistent=False with LIMITED COVERAGE caveat is the correct result
+        assert result.consistent is False
+        assert (
+            "HEURISTIC" in result.message.upper() or "LIMITED" in result.message.upper()
+        )
 
 
 class TestJurisdictionGuard:
     """Test JurisdictionGuard functionality."""
-    
+
     def test_valid_choice_of_law(self):
         """Test valid choice of law verification."""
         from qwed_legal import JurisdictionGuard
+
         guard = JurisdictionGuard()
         result = guard.verify_choice_of_law(
-            parties_countries=["US", "US"],
-            governing_law="Delaware",
-            forum="Delaware"
+            parties_countries=["US", "US"], governing_law="Delaware", forum="Delaware"
         )
         assert result.verified is True
-    
+
     def test_mismatched_governing_law_forum(self):
         """Test mismatch between governing law and forum."""
         from qwed_legal import JurisdictionGuard
+
         guard = JurisdictionGuard()
         result = guard.verify_choice_of_law(
-            parties_countries=["US", "UK"],
-            governing_law="Delaware",
-            forum="London"
+            parties_countries=["US", "UK"], governing_law="Delaware", forum="London"
         )
         # Should detect conflict
         assert len(result.conflicts) > 0 or len(result.warnings) > 0
-    
+
     def test_cisg_applicability(self):
         """Test CISG convention check."""
         from qwed_legal import JurisdictionGuard
+
         guard = JurisdictionGuard()
         result = guard.check_convention_applicability(
-            parties_countries=["US", "DE"],
-            convention="CISG"
+            parties_countries=["US", "DE"], convention="CISG"
         )
         assert result.verified is True
         assert "applies" in result.message.lower()
-    
+
     def test_forum_selection(self):
         """Test forum selection validation."""
         from qwed_legal import JurisdictionGuard
+
         guard = JurisdictionGuard()
         result = guard.verify_forum_selection("NY", contract_value=100000)
         assert result.verified is True
@@ -335,55 +369,59 @@ class TestJurisdictionGuard:
 
 class TestStatuteOfLimitationsGuard:
     """Test StatuteOfLimitationsGuard functionality."""
-    
+
     def test_within_statute(self):
         """Test claim within statute of limitations."""
         from qwed_legal import StatuteOfLimitationsGuard
+
         guard = StatuteOfLimitationsGuard()
         result = guard.verify(
             claim_type="breach_of_contract",
             jurisdiction="California",
             incident_date="2024-01-15",
-            filing_date="2026-06-01"
+            filing_date="2026-06-01",
         )
         assert result.verified is True
         assert "WITHIN" in result.message
-    
+
     def test_expired_statute(self):
         """Test claim past statute of limitations."""
         from qwed_legal import StatuteOfLimitationsGuard
+
         guard = StatuteOfLimitationsGuard()
         result = guard.verify(
             claim_type="breach_of_contract",
             jurisdiction="California",
             incident_date="2018-01-15",
-            filing_date="2026-06-01"
+            filing_date="2026-06-01",
         )
         assert result.verified is False
         assert "EXPIRED" in result.message
-    
+
     def test_get_limitation_period(self):
         """Test getting limitation period."""
         from qwed_legal import StatuteOfLimitationsGuard
+
         guard = StatuteOfLimitationsGuard()
         period = guard.get_limitation_period("breach_of_contract", "California")
         assert period == 4.0
-    
+
     def test_compare_jurisdictions(self):
         """Test comparing limitation periods across jurisdictions."""
         from qwed_legal import StatuteOfLimitationsGuard
+
         guard = StatuteOfLimitationsGuard()
         comparison = guard.compare_jurisdictions(
-            "breach_of_contract",
-            ["California", "New York", "Delaware"]
+            "breach_of_contract", ["California", "New York", "Delaware"]
         )
         assert comparison["California"] == 4.0
         assert comparison["New York"] == 6.0
         assert comparison["Delaware"] == 3.0
-    
+
     def test_india_jurisdiction(self):
         """Test India statute of limitations."""
         from qwed_legal import StatuteOfLimitationsGuard
+
         guard = StatuteOfLimitationsGuard()
         period = guard.get_limitation_period("breach_of_contract", "India")
         assert period == 3.0
@@ -391,4 +429,3 @@ class TestStatuteOfLimitationsGuard:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
-


### PR DESCRIPTION
## Problem (Issue #20)

Three guards were returning verified/consistent results for legal inputs they
**do not model** — violating QWED's fail-closed principle.

> "not understood" should never collapse into "verified"

---

## Root causes & fixes

### ContradictionGuard (full rewrite)
**Root cause:** Unsupported categories (PAYMENT, PENALTY, etc.) were silently
ignored. 0 constraints added → Z3 SAT always → `verified: True`.
A PAYMENT-only input returned `consistent` when the guard had **zero** legal
understanding of it.

**Fix:**
- `SUPPORTED_CATEGORIES = {"DURATION", "LIABILITY"}` declared explicitly
- Empty input → `UNVERIFIABLE`  
- All-unsupported categories → `UNVERIFIABLE` with message listing received vs supported
- Mixed (some supported, some not) → `partial_coverage` status + warning — not silent omission
- Result always carries `status` and `unsupported` keys

### ClauseGuard
**Root cause:** `"VERIFIED: All supported clause checks found no conflicts"` returned
even when **zero propositions** were extractable. Payment-only clauses passed as
verified when the guard had no model for them.

**Fix:**
- Count extractable propositions before returning
- `covered == 0` → `HEURISTIC_PASS (LIMITED COVERAGE)` with explicit caveat
- `covered > 0` → `HEURISTIC_PASS` (not `VERIFIED`)

### JurisdictionGuard
**Root cause:** Unknown party country codes silently skipped legal system
classification, making cross-border analysis incomplete with no signal to caller.

**Fix:** Unknown country codes collected and added to `warnings` with explicit
message that legal system classification is incomplete.

---

## Tests — 22 new in `test_fail_closed_guards.py`
- Empty input, all-unsupported, mixed, novel categories → UNVERIFIABLE
- DURATION/LIABILITY contradictions → still caught
- Consistent clauses → still pass
- Zero-proposition clauses → HEURISTIC_PASS (LIMITED COVERAGE), not VERIFIED
- Unknown party countries → warning present, known ones → no spurious warning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced contradiction detection with granular status outcomes (consistent, partial coverage, contradiction, unverifiable).
  * Improved clause analysis to distinguish deterministic verification from heuristic-based assessments.

* **Bug Fixes**
  * Added detection and warnings for unrecognized party country codes in jurisdiction analysis.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QWED-AI/qwed-legal/pull/27?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->