### PR TITLE
fix(citation): separate format validity from authority proof — closes #17

### DIFF
--- a/qwed_legal/guards/citation_guard.py
+++ b/qwed_legal/guards/citation_guard.py
@@ -240,6 +240,16 @@ class CitationGuard:
                 ),
             )
 
+        # Statute check (done after case patterns to avoid dual-matching)
+        # Important: run this before returning a deferred "Missing case name"
+        # error. Mixed text can contain a bare case reporter fragment (e.g.
+        # "347 U.S. 483") and a valid statute citation. A missing case-name
+        # fragment should not prevent a later valid statute format from being
+        # detected. The result remains FORMAT ONLY / AUTHORITY UNVERIFIABLE.
+        if is_statute:
+            # Let check_statute_citation handle it for a structured result
+            return self.check_statute_citation(text)
+
         # If a reporter pattern matched but was skipped due to missing case name,
         # and no other pattern succeeded, surface "Missing case name" specifically.
         if skipped_for_case_name:
@@ -253,11 +263,6 @@ class CitationGuard:
                     "(expected 'Party v. Party, ...' format for this reporter)."
                 ),
             )
-
-        # Statute check (done after case patterns to avoid dual-matching)
-        if is_statute:
-            # Let check_statute_citation handle it for a structured result
-            return self.check_statute_citation(text)
 
         # Unknown/invalid reporter pattern
         if re.search(r"\d+\s+[A-Z\.]+\s+\d+", text):

--- a/qwed_legal/guards/citation_guard.py
+++ b/qwed_legal/guards/citation_guard.py
@@ -34,6 +34,11 @@ STATUS_FORMAT_INVALID = "format_invalid"
 # check case databases, so authority is always unverifiable.
 STATUS_UNVERIFIABLE_AUTHORITY = "unverifiable_authority"
 
+# Regex for a case name prefix — supports special chars in party names:
+# e.g. "AT&T Mobility LLC v. Concepcion", "U.S. v. Windsor"
+# Anchored at start; accepts any non-newline char before " v. "
+_CASE_NAME_RE = re.compile(r"^.+\sv\.\s\S", re.IGNORECASE)
+
 
 @dataclass
 class CitationResult:
@@ -45,8 +50,11 @@ class CitationResult:
                           Does NOT mean the cited case exists.
         status          — one of STATUS_FORMAT_VALID, STATUS_FORMAT_INVALID,
                           or STATUS_UNVERIFIABLE_AUTHORITY.
+        citation        — the original citation text passed to verify(). Included
+                          so callers and the TypeScript SDK can echo it back.
         citation_type   — reporter category matched (e.g., "US_SCOTUS"), or None.
-        parsed_components — regex-extracted fields (volume, reporter, page, etc.)
+        parsed_components — regex-extracted fields (volume, reporter, page, etc.
+                          Numeric fields are coerced to int where possible.)
         issues          — list of format problems found (empty when format_valid=True)
         message         — human-readable explanation of the result
         risk            — optional risk level string
@@ -54,6 +62,7 @@ class CitationResult:
 
     format_valid: bool
     status: str
+    citation: str = ""  # original input text — for SDK / caller echo-back
     citation_type: Optional[str] = None
     parsed_components: Dict[str, Any] = field(default_factory=dict)
     issues: List[str] = field(default_factory=list)
@@ -112,28 +121,45 @@ class CitationGuard:
     like a real citation." It does not mean: "this legal authority exists."
 
     Downstream consumers MUST check result.status to distinguish:
-      STATUS_FORMAT_VALID / STATUS_UNVERIFIABLE_AUTHORITY  → format ok, authority unknown
-      STATUS_FORMAT_INVALID                                 → format is malformed
+      STATUS_UNVERIFIABLE_AUTHORITY  → format ok, authority unknown (normal passing state)
+      STATUS_FORMAT_INVALID          → citation is malformed
     """
 
-    # Known case citation reporter patterns
+    # Known case citation reporter patterns.
+    # Patterns for case reporters (US_SCOTUS, US_FED) require a case name to
+    # appear BEFORE the reporter group. Neutral citation patterns (UK_NEUTRAL)
+    # do not mandate a party-name prefix.
     CASE_PATTERNS: Dict[str, str] = {
-        "US_SCOTUS": r"(?P<volume>\d{1,4})\s+(?P<reporter>U\.?S\.?)\s+(?P<page>\d{1,4})",
-        "US_FED": r"(?P<volume>\d{1,4})\s+(?P<reporter>F\.(?:2d|3d)?)\s+(?P<page>\d{1,4})",
-        "UK_NEUTRAL": r"\[(?P<year>\d{4})\]\s+(?P<court>UKSC|EWCA\s+Civ|EWHC)\s+(?P<number>\d+)",
-        "INDIA_AIR": r"AIR\s+(?P<year>\d{4})\s+(?P<court>SC|Bom|Del)\s+(?P<page>\d+)",
+        # U.S. Supreme Court: "Brown v. Board, 347 U.S. 483"
+        # Case name enforced by requiring .+ v. . prefix before the volume/reporter
+        "US_SCOTUS": (
+            r"(?i)(?:.+\sv\.\s\S.+?\s)?"
+            r"(?P<volume>\d{1,4})\s+(?P<reporter>U\.?S\.?)\s+(?P<page>\d{1,4})"
+        ),
+        # Federal Reporter: "Smith v. Jones, 123 F.3d 456"
+        "US_FED": (
+            r"(?i)(?:.+\sv\.\s\S.+?\s)?"
+            r"(?P<volume>\d{1,4})\s+(?P<reporter>F\.(?:2d|3d)?)\s+(?P<page>\d{1,4})"
+        ),
+        # UK Neutral: "[2020] UKSC 5" — no party names required
+        "UK_NEUTRAL": (
+            r"\[(?P<year>\d{4})\]\s+(?P<court>UKSC|EWCA\s+Civ|EWHC)\s+(?P<number>\d+)"
+        ),
+        # India AIR: "AIR 2001 SC 3021" — no party names required
+        "INDIA_AIR": (r"AIR\s+(?P<year>\d{4})\s+(?P<court>SC|Bom|Del)\s+(?P<page>\d+)"),
     }
+
+    # Case reporter types that require a "Party v. Party" prefix to be format-valid.
+    # Neutral citation types (UK_NEUTRAL, INDIA_AIR) do not require party names.
+    _REQUIRES_CASE_NAME = frozenset({"US_SCOTUS", "US_FED"})
 
     # Known statute citation patterns
     STATUTE_PATTERNS: Dict[str, str] = {
         "US_CODE": r"(?P<title>\d{1,3})\s+U\.?S\.?C\.?\s+§+\s*(?P<section>[\d\w]+)",
     }
 
-    # Regex for a case name prefix: "Something v. Something"
-    _CASE_NAME_RE = re.compile(r"^([A-Z][a-zA-Z\s\.]+)\sv\.\s([A-Z][a-zA-Z\s\.,]+)")
-
     def __init__(self) -> None:
-        # Compile patterns once
+        # Compile patterns once at init time (not dynamically at runtime)
         self._compiled_case = {k: re.compile(v) for k, v in self.CASE_PATTERNS.items()}
         self._compiled_statute = {
             k: re.compile(v) for k, v in self.STATUTE_PATTERNS.items()
@@ -147,7 +173,7 @@ class CitationGuard:
 
         Returns CitationResult with:
           format_valid=True  + status=STATUS_UNVERIFIABLE_AUTHORITY
-              when a reporter pattern matches.
+              when a reporter pattern matches (and case-name is present if required).
               WARNING: this does NOT confirm the cited case exists.
 
           format_valid=False + status=STATUS_FORMAT_INVALID
@@ -156,44 +182,57 @@ class CitationGuard:
         Authority is ALWAYS unverifiable — CitationGuard has no database access.
         """
         is_statute = "U.S.C." in text or "§" in text
-        has_case_name = bool(self._CASE_NAME_RE.search(text))
 
-        if not has_case_name and not is_statute:
-            if re.search(r"\d+\s+[A-Za-z\.]+\s+\d+", text):
-                return CitationResult(
-                    format_valid=False,
-                    status=STATUS_FORMAT_INVALID,
-                    issues=["Missing case name"],
-                    message=(
-                        "FORMAT INVALID: Citation is missing a case name "
-                        "(expected 'Party v. Party, ...' format)."
-                    ),
-                )
-
-        # Try each case reporter pattern
+        # Try each case reporter pattern.
+        # Case-name enforcement is per-pattern: US_SCOTUS and US_FED require a
+        # "Party v. Party" prefix; UK_NEUTRAL and INDIA_AIR do not.
         for citation_type, pattern in self._compiled_case.items():
             match = pattern.search(text)
-            if match:
-                components = self._parse_components(match.groupdict())
-                return CitationResult(
-                    format_valid=True,
-                    status=STATUS_UNVERIFIABLE_AUTHORITY,
-                    citation_type=citation_type,
-                    parsed_components=components,
-                    message=(
-                        f"FORMAT VALID ({citation_type}): Citation matches the "
-                        f"{citation_type} reporter pattern. "
-                        f"AUTHORITY UNVERIFIABLE: CitationGuard cannot confirm "
-                        f"this case exists or is correctly identified. "
-                        f"Format match is not proof of legal authority."
-                    ),
-                )
+            if not match:
+                continue
+
+            # For reporter types that mandate a case name, verify one is present.
+            if citation_type in self._REQUIRES_CASE_NAME:
+                if not _CASE_NAME_RE.search(text):
+                    return CitationResult(
+                        format_valid=False,
+                        status=STATUS_FORMAT_INVALID,
+                        citation=text,
+                        issues=["Missing case name"],
+                        message=(
+                            "FORMAT INVALID: Citation is missing a case name "
+                            "(expected 'Party v. Party, ...' format for "
+                            f"{citation_type} reporter)."
+                        ),
+                    )
+
+            components = self._parse_components(match.groupdict())
+            return CitationResult(
+                format_valid=True,
+                status=STATUS_UNVERIFIABLE_AUTHORITY,
+                citation=text,
+                citation_type=citation_type,
+                parsed_components=components,
+                message=(
+                    f"FORMAT VALID ({citation_type}): Citation matches the "
+                    f"{citation_type} reporter pattern. "
+                    f"AUTHORITY UNVERIFIABLE: CitationGuard cannot confirm "
+                    f"this case exists or is correctly identified. "
+                    f"Format match is not proof of legal authority."
+                ),
+            )
+
+        # Statute check (done after case patterns to avoid dual-matching)
+        if is_statute:
+            # Let check_statute_citation handle it for a structured result
+            return self.check_statute_citation(text)
 
         # Unknown/invalid reporter pattern
         if re.search(r"\d+\s+[A-Z\.]+\s+\d+", text):
             return CitationResult(
                 format_valid=False,
                 status=STATUS_FORMAT_INVALID,
+                citation=text,
                 issues=["Unknown reporter"],
                 message=(
                     "FORMAT INVALID: Citation contains an unrecognized reporter "
@@ -205,6 +244,7 @@ class CitationGuard:
         return CitationResult(
             format_valid=False,
             status=STATUS_FORMAT_INVALID,
+            citation=text,
             issues=["No valid citation found"],
             message="FORMAT INVALID: No recognizable citation pattern found in the text.",
         )
@@ -213,17 +253,24 @@ class CitationGuard:
         """
         Explicit format-check API. Returns a dict describing format validity only.
 
-        Prefer verify() for structured results. This method is provided for
-        backward compatibility and for callers who explicitly want format info.
+        Backward-compat note:
+          - 'verified' key is retained as a deprecated alias for format_valid.
+            It reflects whether the citation FORMAT is valid, NOT whether the
+            legal authority exists. New code should use 'format_valid' instead.
+          - 'authority_verified' is always False (canonical field for auth check).
         """
         result = self.verify(text)
         return {
             "format_valid": result.format_valid,
+            # Deprecated alias — equals format_valid, not authority verification.
+            # Kept for backward compatibility. Use 'format_valid' in new code.
+            "verified": result.format_valid,
             "status": result.status,
             "citation_type": result.citation_type,
+            "citation": result.citation,
             "issues": result.issues,
             "message": result.message,
-            # Explicit note — not a property alias, an intentional field
+            # Explicit authority fields — these are the canonical source of truth
             "authority_verified": False,
             "authority_note": (
                 "CitationGuard performs format validation only. "
@@ -245,6 +292,7 @@ class CitationGuard:
                 return CitationResult(
                     format_valid=True,
                     status=STATUS_UNVERIFIABLE_AUTHORITY,
+                    citation=text,
                     citation_type=citation_type,
                     parsed_components=components,
                     message=(
@@ -258,6 +306,7 @@ class CitationGuard:
         return CitationResult(
             format_valid=False,
             status=STATUS_FORMAT_INVALID,
+            citation=text,
             issues=["Invalid statute format"],
             message=(
                 "FORMAT INVALID: No recognized statute citation pattern found. "
@@ -284,10 +333,16 @@ class CitationGuard:
 
     @staticmethod
     def _parse_components(groupdict: Dict[str, Any]) -> Dict[str, Any]:
-        """Coerce numeric fields (volume, title, page, number) to int where possible."""
+        """
+        Coerce numeric fields to int where possible.
+
+        Fields coerced: volume, title, page, number, year.
+        All other fields are left as-is.
+        """
+        _NUMERIC_FIELDS = {"volume", "title", "page", "number", "year"}
         result = {}
         for key, value in groupdict.items():
-            if value is not None and key in {"volume", "title", "page", "number"}:
+            if value is not None and key in _NUMERIC_FIELDS:
                 try:
                     result[key] = int(value)
                 except (ValueError, TypeError):

--- a/qwed_legal/guards/citation_guard.py
+++ b/qwed_legal/guards/citation_guard.py
@@ -1,116 +1,297 @@
+"""
+CitationGuard: Validate legal citation format.
+
+IMPORTANT — scope of this guard:
+  CitationGuard checks whether a citation STRING matches a known reporter
+  pattern (e.g., U.S., F.3d, UKSC). This is FORMAT validation only.
+
+  Format validity is NOT authority validity:
+  - A well-formatted citation may refer to a case that does not exist.
+  - A hallucinated citation with a plausible reporter still passes format checks.
+  - This guard has no access to case law databases, and cannot confirm that the
+    cited authority exists, is correctly identified, or applies to the claim made.
+
+  Consumers MUST treat CitationGuard results as FORMAT_VALID / FORMAT_INVALID,
+  never as VERIFIED legal authority. The status field makes this explicit:
+    status="format_valid"            — matches a known reporter pattern
+    status="format_invalid"          — does not match any pattern
+    status="unverifiable_authority"  — format is valid but authority is unconfirmed
+
+  A status of "format_valid" or "unverifiable_authority" does NOT mean the
+  cited case exists. Authority verification requires an external legal database.
+"""
+
 import re
-from typing import Dict, Any, List, Optional
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
 
+
+# Status constants — use these instead of comparing strings directly
+STATUS_FORMAT_VALID = "format_valid"
+STATUS_FORMAT_INVALID = "format_invalid"
+# Returned alongside format_valid when authority cannot be confirmed.
+# This is ALWAYS set when a format match is found — CitationGuard cannot
+# check case databases, so authority is always unverifiable.
+STATUS_UNVERIFIABLE_AUTHORITY = "unverifiable_authority"
+
+
+@dataclass
 class CitationResult:
-    """Helper class to match test expectations for object attributes (result.valid)."""
-    def __init__(self, valid: bool, parsed_components: Optional[Dict[str, Any]] = None, issues: Optional[List[str]] = None, risk: str = ""):
-        self.valid = valid
-        self.parsed_components = parsed_components or {}
-        self.issues = issues or []
-        self.risk = risk
-        self.verified = valid # Alias
+    """
+    Result of a citation format check.
 
+    Fields:
+        format_valid    — True if citation matches a known reporter pattern.
+                          Does NOT mean the cited case exists.
+        status          — one of STATUS_FORMAT_VALID, STATUS_FORMAT_INVALID,
+                          or STATUS_UNVERIFIABLE_AUTHORITY.
+        citation_type   — reporter category matched (e.g., "US_SCOTUS"), or None.
+        parsed_components — regex-extracted fields (volume, reporter, page, etc.)
+        issues          — list of format problems found (empty when format_valid=True)
+        message         — human-readable explanation of the result
+        risk            — optional risk level string
+    """
+
+    format_valid: bool
+    status: str
+    citation_type: Optional[str] = None
+    parsed_components: Dict[str, Any] = field(default_factory=dict)
+    issues: List[str] = field(default_factory=list)
+    message: str = ""
+    risk: Optional[str] = None
+
+    # ── Backward-compatibility properties ─────────────────────────────────────
+    @property
+    def valid(self) -> bool:
+        """Alias for format_valid. Use format_valid in new code."""
+        return self.format_valid
+
+    @property
+    def verified(self) -> bool:
+        """
+        Always False.
+
+        CitationGuard cannot verify legal authority — it has no access to case
+        law databases. Returning True here would be a false claim of authority
+        proof. Use format_valid to check citation format only.
+        """
+        return False
+
+
+@dataclass
 class BatchCitationResult:
-    """Helper class for batch results."""
-    def __init__(self, total: int, valid: int, invalid: int):
-        self.total = total
-        self.valid = valid
-        self.invalid = invalid
+    """Result of a batch citation format check."""
+
+    total: int
+    format_valid: int
+    format_invalid: int
+
+    # Backward-compat aliases
+    @property
+    def valid(self) -> int:
+        return self.format_valid
+
+    @property
+    def invalid(self) -> int:
+        return self.format_invalid
+
 
 class CitationGuard:
     """
-    Verifies that legal citations follow standard reporter formats.
-    Prevents 'Hallucinated Citations' like 'Mata v. Avianca'.
+    Validate legal citation format against known reporter patterns.
+
+    Scope: FORMAT CHECKING ONLY.
+
+    This guard does NOT:
+    - Confirm a cited case exists in any database.
+    - Validate that a case name is real or correctly identified.
+    - Verify that a cited authority supports the proposition claimed.
+    - Detect hallucinated citations that use plausible reporter formats.
+
+    A CitationResult with format_valid=True means: "the citation STRING looks
+    like a real citation." It does not mean: "this legal authority exists."
+
+    Downstream consumers MUST check result.status to distinguish:
+      STATUS_FORMAT_VALID / STATUS_UNVERIFIABLE_AUTHORITY  → format ok, authority unknown
+      STATUS_FORMAT_INVALID                                 → format is malformed
     """
-    def __init__(self):
-        # Regex for common US/UK Reporters (e.g., "501 U.S. 321", "2023 EWCA Civ 10")
-        self.patterns = {
-            "US_SCOTUS": r"(?P<volume>\d{1,4})\s+(?P<reporter>U\.?S\.?)\s+(?P<page>\d{1,4})",
-            "US_FED": r"(?P<volume>\d{1,4})\s+(?P<reporter>F\.(?:2d|3d)?)\s+(?P<page>\d{1,4})",
-            "UK_NEUTRAL": r"\[(?P<year>\d{4})\]\s+(?P<court>UKSC|EWCA\s+Civ|EWHC)\s+(?P<number>\d+)",
-            "INDIA_AIR": r"AIR\s+(?P<year>\d{4})\s+(?P<court>SC|Bom|Del)\s+(?P<page>\d+)"
+
+    # Known case citation reporter patterns
+    CASE_PATTERNS: Dict[str, str] = {
+        "US_SCOTUS": r"(?P<volume>\d{1,4})\s+(?P<reporter>U\.?S\.?)\s+(?P<page>\d{1,4})",
+        "US_FED": r"(?P<volume>\d{1,4})\s+(?P<reporter>F\.(?:2d|3d)?)\s+(?P<page>\d{1,4})",
+        "UK_NEUTRAL": r"\[(?P<year>\d{4})\]\s+(?P<court>UKSC|EWCA\s+Civ|EWHC)\s+(?P<number>\d+)",
+        "INDIA_AIR": r"AIR\s+(?P<year>\d{4})\s+(?P<court>SC|Bom|Del)\s+(?P<page>\d+)",
+    }
+
+    # Known statute citation patterns
+    STATUTE_PATTERNS: Dict[str, str] = {
+        "US_CODE": r"(?P<title>\d{1,3})\s+U\.?S\.?C\.?\s+§+\s*(?P<section>[\d\w]+)",
+    }
+
+    # Regex for a case name prefix: "Something v. Something"
+    _CASE_NAME_RE = re.compile(r"^([A-Z][a-zA-Z\s\.]+)\sv\.\s([A-Z][a-zA-Z\s\.,]+)")
+
+    def __init__(self) -> None:
+        # Compile patterns once
+        self._compiled_case = {k: re.compile(v) for k, v in self.CASE_PATTERNS.items()}
+        self._compiled_statute = {
+            k: re.compile(v) for k, v in self.STATUTE_PATTERNS.items()
         }
-        self.statute_patterns = {
-           "US_CODE": r"(?P<title>\d{1,3})\s+U\.?S\.?C\.?\s+§+\s*(?P<section>[\d\w]+)" 
-        }
+
+    # ── Public API ─────────────────────────────────────────────────────────────
 
     def verify(self, text: str) -> CitationResult:
         """
-        Scans text for a valid legal citation match.
-        Used by tests: result.valid, result.parsed_components.get("volume")
+        Check whether `text` matches a known legal citation format.
+
+        Returns CitationResult with:
+          format_valid=True  + status=STATUS_UNVERIFIABLE_AUTHORITY
+              when a reporter pattern matches.
+              WARNING: this does NOT confirm the cited case exists.
+
+          format_valid=False + status=STATUS_FORMAT_INVALID
+              when no pattern matches or required elements are missing.
+
+        Authority is ALWAYS unverifiable — CitationGuard has no database access.
         """
-        # Case Name Check: Must look like "Something v. Something" or valid statute
-        # But this method seems to be checking a SINGLE citation string in tests, e.g. "Brown v. Board ..., 347 U.S. 483"
-        
-        # 1. Parse Case Name
-        case_name_match = re.search(r"^([A-Z][a-zA-Z\s\.]+)\sv\.\s([A-Z][a-zA-Z\s\.,]+)", text)
         is_statute = "U.S.C." in text or "§" in text
-        
-        if not case_name_match and not is_statute:
-             # Basic heuristic from tests: "123 U.S. 456" fails "missing case name"
-             # "Fake v. Case" works for name, but might fail reporter.
-             
-             # If it looks like a citation but no name:
-             if re.search(r"\d+\s+[A-Za-z\.]+\s+\d+", text):
-                 return CitationResult(False, issues=["Missing case name"])
+        has_case_name = bool(self._CASE_NAME_RE.search(text))
 
-        # 2. Check Reporters
-        for key, pat in self.patterns.items():
-            match = re.search(pat, text)
+        if not has_case_name and not is_statute:
+            if re.search(r"\d+\s+[A-Za-z\.]+\s+\d+", text):
+                return CitationResult(
+                    format_valid=False,
+                    status=STATUS_FORMAT_INVALID,
+                    issues=["Missing case name"],
+                    message=(
+                        "FORMAT INVALID: Citation is missing a case name "
+                        "(expected 'Party v. Party, ...' format)."
+                    ),
+                )
+
+        # Try each case reporter pattern
+        for citation_type, pattern in self._compiled_case.items():
+            match = pattern.search(text)
             if match:
-                components = match.groupdict()
-                # Convert volume to int if present, for tests
-                if "volume" in components:
-                    try:
-                        components["volume"] = int(components["volume"])
-                    except (ValueError, TypeError): 
-                        pass
-                
-                return CitationResult(True, parsed_components=components)
+                components = self._parse_components(match.groupdict())
+                return CitationResult(
+                    format_valid=True,
+                    status=STATUS_UNVERIFIABLE_AUTHORITY,
+                    citation_type=citation_type,
+                    parsed_components=components,
+                    message=(
+                        f"FORMAT VALID ({citation_type}): Citation matches the "
+                        f"{citation_type} reporter pattern. "
+                        f"AUTHORITY UNVERIFIABLE: CitationGuard cannot confirm "
+                        f"this case exists or is correctly identified. "
+                        f"Format match is not proof of legal authority."
+                    ),
+                )
 
-        # 3. Check Unknown/Invalid Reporter
-        # e.g. "999 X.Y.Z. 123"
+        # Unknown/invalid reporter pattern
         if re.search(r"\d+\s+[A-Z\.]+\s+\d+", text):
-             return CitationResult(False, issues=["Unknown reporter"])
-             
-        return CitationResult(False, issues=["No valid citation found"])
+            return CitationResult(
+                format_valid=False,
+                status=STATUS_FORMAT_INVALID,
+                issues=["Unknown reporter"],
+                message=(
+                    "FORMAT INVALID: Citation contains an unrecognized reporter "
+                    "abbreviation. Supported reporters: "
+                    f"{', '.join(self.CASE_PATTERNS.keys())}."
+                ),
+            )
 
-    def verify_batch(self, citations: List[str]) -> BatchCitationResult:
+        return CitationResult(
+            format_valid=False,
+            status=STATUS_FORMAT_INVALID,
+            issues=["No valid citation found"],
+            message="FORMAT INVALID: No recognizable citation pattern found in the text.",
+        )
+
+    def verify_citation_format(self, text: str) -> Dict[str, Any]:
         """
-        Verifies a list of citations.
+        Explicit format-check API. Returns a dict describing format validity only.
+
+        Prefer verify() for structured results. This method is provided for
+        backward compatibility and for callers who explicitly want format info.
         """
-        valid_count = 0
-        invalid_count = 0
-        for cite in citations:
-            res = self.verify(cite)
-            if res.valid:
-                valid_count += 1
-            else:
-                invalid_count += 1
-        
-        return BatchCitationResult(len(citations), valid_count, invalid_count)
+        result = self.verify(text)
+        return {
+            "format_valid": result.format_valid,
+            "status": result.status,
+            "citation_type": result.citation_type,
+            "issues": result.issues,
+            "message": result.message,
+            # Explicit note — not a property alias, an intentional field
+            "authority_verified": False,
+            "authority_note": (
+                "CitationGuard performs format validation only. "
+                "Authority verification requires an external legal database."
+            ),
+        }
 
     def check_statute_citation(self, text: str) -> CitationResult:
         """
-        Verifies statute citations like '42 U.S.C. § 1983'.
-        """
-        for key, pat in self.statute_patterns.items():
-            match = re.search(pat, text)
-            if match:
-                components = match.groupdict()
-                if "title" in components:
-                    try:
-                        components["title"] = int(components["title"])
-                    except (ValueError, TypeError):
-                        pass
-                return CitationResult(True, parsed_components=components)
-        
-        return CitationResult(False, issues=["Invalid statute format"])
+        Check whether `text` matches a known statute citation format (e.g., 42 U.S.C. § 1983).
 
-    # Keep original method for backward compatibility/other usage if needed, or alias it
-    def verify_citation_format(self, text: str) -> Dict[str, Any]:
-        res = self.verify(text)
-        return {
-            "verified": res.valid,
-            "issues": res.issues
-        }
+        Same scope as verify(): FORMAT ONLY. Does not confirm the statute section exists
+        or has the legal meaning attributed to it.
+        """
+        for citation_type, pattern in self._compiled_statute.items():
+            match = pattern.search(text)
+            if match:
+                components = self._parse_components(match.groupdict())
+                return CitationResult(
+                    format_valid=True,
+                    status=STATUS_UNVERIFIABLE_AUTHORITY,
+                    citation_type=citation_type,
+                    parsed_components=components,
+                    message=(
+                        f"FORMAT VALID ({citation_type}): Statute citation matches "
+                        f"the {citation_type} pattern. "
+                        f"AUTHORITY UNVERIFIABLE: CitationGuard cannot confirm "
+                        f"this statute section exists or applies as cited."
+                    ),
+                )
+
+        return CitationResult(
+            format_valid=False,
+            status=STATUS_FORMAT_INVALID,
+            issues=["Invalid statute format"],
+            message=(
+                "FORMAT INVALID: No recognized statute citation pattern found. "
+                f"Supported patterns: {', '.join(self.STATUTE_PATTERNS.keys())}."
+            ),
+        )
+
+    def verify_batch(self, citations: List[str]) -> BatchCitationResult:
+        """
+        Check a list of citation strings for format validity.
+
+        Returns counts of format_valid and format_invalid. Note that format_valid
+        citations are NOT verified legal authorities — see verify() for details.
+        """
+        valid_count = sum(1 for c in citations if self.verify(c).format_valid)
+        invalid_count = len(citations) - valid_count
+        return BatchCitationResult(
+            total=len(citations),
+            format_valid=valid_count,
+            format_invalid=invalid_count,
+        )
+
+    # ── Private helpers ────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _parse_components(groupdict: Dict[str, Any]) -> Dict[str, Any]:
+        """Coerce numeric fields (volume, title, page, number) to int where possible."""
+        result = {}
+        for key, value in groupdict.items():
+            if value is not None and key in {"volume", "title", "page", "number"}:
+                try:
+                    result[key] = int(value)
+                except (ValueError, TypeError):
+                    result[key] = value
+            else:
+                result[key] = value
+        return result

--- a/qwed_legal/guards/citation_guard.py
+++ b/qwed_legal/guards/citation_guard.py
@@ -40,10 +40,10 @@ from typing import Any, Dict, List, Optional
 STATUS_FORMAT_INVALID = "format_invalid"
 STATUS_UNVERIFIABLE_AUTHORITY = "unverifiable_authority"
 
-# Regex for a case name prefix — supports special chars in party names:
-# e.g. "AT&T Mobility LLC v. Concepcion", "U.S. v. Windsor"
-# Anchored at start; accepts any non-newline char before " v. "
-_CASE_NAME_RE = re.compile(r"^.+\sv\.\s\S", re.IGNORECASE)
+# Pattern that matches " v. " — the defining element of a party-vs-party case name.
+# Used positionally: we require this marker to appear BEFORE the reporter match start,
+# not just anywhere in the string.
+_V_DOT_RE = re.compile(r"\sv\.\s", re.IGNORECASE)
 
 
 @dataclass
@@ -202,12 +202,25 @@ class CitationGuard:
             if not match:
                 continue
 
-            # For reporter types that mandate a case name, verify one is present.
-            # Use continue (not return): another pattern later in the loop may
-            # match the same text without requiring a case name (e.g. INDIA_AIR).
-            # Returning early would prevent those patterns from being evaluated.
+            # For reporter types that mandate a case name, verify one is present
+            # AND that it appears BEFORE the reporter in the string.
+            # Positional check prevents "347 U.S. 483 Smith v. Jones" from passing
+            # (case name after reporter is not a valid citation prefix).
+            # Use continue (not return): a later pattern may match without case name.
             if citation_type in self._REQUIRES_CASE_NAME:
-                if not _CASE_NAME_RE.search(text):
+                v_dot = _V_DOT_RE.search(text)
+                # "v." must exist AND appear before the volume number.
+                # Use match.start("volume") — the volume group is always the first
+                # numeric capture and is the true start of the reporter section.
+                # match.start() alone would be 0 because the pattern has an optional
+                # case-name prefix group, making match.start() unreliable here.
+                volume_start = (
+                    match.start("volume")
+                    if "volume" in match.groupdict()
+                    else match.start()
+                )
+                if not v_dot or v_dot.start() >= volume_start:
+                    # No "v." found, or "v." at/after reporter — case name not a prefix
                     skipped_for_case_name = True
                     continue
 

--- a/qwed_legal/guards/citation_guard.py
+++ b/qwed_legal/guards/citation_guard.py
@@ -13,12 +13,13 @@ IMPORTANT — scope of this guard:
 
   Consumers MUST treat CitationGuard results as FORMAT_VALID / FORMAT_INVALID,
   never as VERIFIED legal authority. The status field makes this explicit:
-    status="format_valid"            — matches a known reporter pattern
-    status="format_invalid"          — does not match any pattern
-    status="unverifiable_authority"  — format is valid but authority is unconfirmed
+    status="format_invalid"          — does not match any known reporter pattern
+    status="unverifiable_authority"  — matches a pattern; authority unconfirmed
+                                       (this is the normal result for valid-format
+                                       citations — format ≠ authority)
 
-  A status of "format_valid" or "unverifiable_authority" does NOT mean the
-  cited case exists. Authority verification requires an external legal database.
+  A status of "unverifiable_authority" does NOT mean the cited case exists.
+  Authority verification requires an external legal database.
 """
 
 import re
@@ -27,11 +28,16 @@ from typing import Any, Dict, List, Optional
 
 
 # Status constants — use these instead of comparing strings directly
-STATUS_FORMAT_VALID = "format_valid"
+#
+# Possible values returned by verify() and check_statute_citation():
+#   STATUS_FORMAT_INVALID          — citation does not match any known pattern
+#   STATUS_UNVERIFIABLE_AUTHORITY  — citation matches a pattern but authority
+#                                   cannot be confirmed (no database access)
+#
+# Note: there is intentionally NO "format_valid" status. When a citation matches
+# a reporter pattern, status is ALWAYS "unverifiable_authority" — because format
+# validity does not imply authority validity and must not be confused with it.
 STATUS_FORMAT_INVALID = "format_invalid"
-# Returned alongside format_valid when authority cannot be confirmed.
-# This is ALWAYS set when a format match is found — CitationGuard cannot
-# check case databases, so authority is always unverifiable.
 STATUS_UNVERIFIABLE_AUTHORITY = "unverifiable_authority"
 
 # Regex for a case name prefix — supports special chars in party names:
@@ -48,8 +54,10 @@ class CitationResult:
     Fields:
         format_valid    — True if citation matches a known reporter pattern.
                           Does NOT mean the cited case exists.
-        status          — one of STATUS_FORMAT_VALID, STATUS_FORMAT_INVALID,
-                          or STATUS_UNVERIFIABLE_AUTHORITY.
+        status          — one of STATUS_FORMAT_INVALID or STATUS_UNVERIFIABLE_AUTHORITY.
+                          Note: STATUS_FORMAT_VALID is never returned — when a citation
+                          matches a pattern, status is always STATUS_UNVERIFIABLE_AUTHORITY
+                          because format validity does not imply authority validity.
         citation        — the original citation text passed to verify(). Included
                           so callers and the TypeScript SDK can echo it back.
         citation_type   — reporter category matched (e.g., "US_SCOTUS"), or None.

--- a/qwed_legal/guards/citation_guard.py
+++ b/qwed_legal/guards/citation_guard.py
@@ -186,25 +186,22 @@ class CitationGuard:
         # Try each case reporter pattern.
         # Case-name enforcement is per-pattern: US_SCOTUS and US_FED require a
         # "Party v. Party" prefix; UK_NEUTRAL and INDIA_AIR do not.
+        # We track whether any pattern matched but was skipped due to missing
+        # case name — used to surface the right error message if no pattern succeeds.
+        skipped_for_case_name = False
         for citation_type, pattern in self._compiled_case.items():
             match = pattern.search(text)
             if not match:
                 continue
 
             # For reporter types that mandate a case name, verify one is present.
+            # Use continue (not return): another pattern later in the loop may
+            # match the same text without requiring a case name (e.g. INDIA_AIR).
+            # Returning early would prevent those patterns from being evaluated.
             if citation_type in self._REQUIRES_CASE_NAME:
                 if not _CASE_NAME_RE.search(text):
-                    return CitationResult(
-                        format_valid=False,
-                        status=STATUS_FORMAT_INVALID,
-                        citation=text,
-                        issues=["Missing case name"],
-                        message=(
-                            "FORMAT INVALID: Citation is missing a case name "
-                            "(expected 'Party v. Party, ...' format for "
-                            f"{citation_type} reporter)."
-                        ),
-                    )
+                    skipped_for_case_name = True
+                    continue
 
             components = self._parse_components(match.groupdict())
             return CitationResult(
@@ -219,6 +216,20 @@ class CitationGuard:
                     f"AUTHORITY UNVERIFIABLE: CitationGuard cannot confirm "
                     f"this case exists or is correctly identified. "
                     f"Format match is not proof of legal authority."
+                ),
+            )
+
+        # If a reporter pattern matched but was skipped due to missing case name,
+        # and no other pattern succeeded, surface "Missing case name" specifically.
+        if skipped_for_case_name:
+            return CitationResult(
+                format_valid=False,
+                status=STATUS_FORMAT_INVALID,
+                citation=text,
+                issues=["Missing case name"],
+                message=(
+                    "FORMAT INVALID: Citation is missing a case name "
+                    "(expected 'Party v. Party, ...' format for this reporter)."
                 ),
             )
 

--- a/tests/test_citation_guard.py
+++ b/tests/test_citation_guard.py
@@ -366,3 +366,28 @@ class TestCitationReviewFixes:
     # The action_entrypoint.py correctly gates failure on format_invalid only.
     # Adding a test to confirm action_entrypoint logic is unchanged would require
     # subprocess testing; that is out of scope for unit tests.
+
+
+class TestCitationEarlyReturnBug:
+    """Sentry MEDIUM: premature return prevented later patterns from being checked."""
+
+    def setup_method(self):
+        self.guard = CitationGuard()
+
+    def test_neutral_citation_not_blocked_by_scotus_miss(self):
+        """UK neutral citation must not be rejected because US_SCOTUS had a partial match."""
+        result = self.guard.verify("[2020] UKSC 5")
+        assert result.format_valid is True
+        assert result.citation_type == "UK_NEUTRAL"
+
+    def test_india_air_not_blocked_by_earlier_pattern(self):
+        """INDIA_AIR must be evaluated even if an earlier pattern partially matched."""
+        result = self.guard.verify("AIR 2001 SC 3021")
+        assert result.format_valid is True
+        assert result.citation_type == "INDIA_AIR"
+
+    def test_bare_scotus_reporter_no_case_name_is_format_invalid(self):
+        """No case name, no alternative pattern: must still return format_invalid."""
+        result = self.guard.verify("347 U.S. 483")
+        assert result.format_valid is False
+        assert result.status == "format_invalid"

--- a/tests/test_citation_guard.py
+++ b/tests/test_citation_guard.py
@@ -394,3 +394,35 @@ class TestCitationEarlyReturnBug:
         result = self.guard.verify("347 U.S. 483")
         assert result.format_valid is False
         assert result.status == "format_invalid"
+
+
+class TestCaseNamePositionCheck:
+    """Sentry LOW: case name v. must appear before the reporter volume, not after."""
+
+    def setup_method(self):
+        self.guard = CitationGuard()
+
+    def test_case_name_after_reporter_is_format_invalid(self):
+        """'347 U.S. 483 Smith v. Jones' must be invalid -- name is after reporter."""
+        result = self.guard.verify("347 U.S. 483 Smith v. Jones")
+        assert result.format_valid is False
+        assert result.status == STATUS_FORMAT_INVALID
+
+    def test_case_name_before_reporter_is_valid(self):
+        """Normal citation with name before reporter must pass."""
+        result = self.guard.verify("Brown v. Board of Education, 347 U.S. 483 (1954)")
+        assert result.format_valid is True
+        assert result.status == STATUS_UNVERIFIABLE_AUTHORITY
+
+    def test_atandt_before_reporter_passes(self):
+        """Special-char party name before reporter must still pass."""
+        result = self.guard.verify(
+            "AT&T Mobility LLC v. Concepcion, 563 U.S. 333 (2011)"
+        )
+        assert result.format_valid is True
+
+    def test_federal_reporter_name_after_reporter_invalid(self):
+        """Same positional check applies to F.3d reporter."""
+        result = self.guard.verify("123 F.3d 456 Fake v. Case")
+        assert result.format_valid is False
+        assert result.status == STATUS_FORMAT_INVALID

--- a/tests/test_citation_guard.py
+++ b/tests/test_citation_guard.py
@@ -13,7 +13,6 @@ Key invariants:
 
 from qwed_legal.guards.citation_guard import (
     CitationGuard,
-    STATUS_FORMAT_VALID,
     STATUS_FORMAT_INVALID,
     STATUS_UNVERIFIABLE_AUTHORITY,
 )
@@ -237,13 +236,17 @@ class TestStatusConstants:
     """Status constants are importable and have correct values."""
 
     def test_status_constants_exist(self):
-        assert STATUS_FORMAT_VALID == "format_valid"
+        """Only STATUS_FORMAT_INVALID and STATUS_UNVERIFIABLE_AUTHORITY are returned."""
         assert STATUS_FORMAT_INVALID == "format_invalid"
         assert STATUS_UNVERIFIABLE_AUTHORITY == "unverifiable_authority"
 
-    def test_format_valid_and_unverifiable_are_distinct(self):
-        """format_valid status and unverifiable_authority are separate concepts."""
-        assert STATUS_FORMAT_VALID != STATUS_UNVERIFIABLE_AUTHORITY
+    def test_format_valid_status_never_returned(self):
+        """format_valid status is never returned — would conflate format with authority."""
+        from qwed_legal.guards.citation_guard import CitationGuard as CG
+
+        r = CG().verify("Brown v. Board of Education, 347 U.S. 483 (1954)")
+        assert r.status != "format_valid"
+        assert r.status == STATUS_UNVERIFIABLE_AUTHORITY
 
 
 class TestCitationReviewFixes:

--- a/tests/test_citation_guard.py
+++ b/tests/test_citation_guard.py
@@ -244,3 +244,125 @@ class TestStatusConstants:
     def test_format_valid_and_unverifiable_are_distinct(self):
         """format_valid status and unverifiable_authority are separate concepts."""
         assert STATUS_FORMAT_VALID != STATUS_UNVERIFIABLE_AUTHORITY
+
+
+class TestCitationReviewFixes:
+    """
+    Tests covering all valid PR review comments.
+
+    Sentry HIGH   — citation field present and populated
+    Codex P2      — deprecated 'verified' key restored in verify_citation_format()
+    CodeRabbit    — AT&T and other special-char party names not misclassified
+    CodeRabbit    — UK neutral citations accepted without case name
+    CodeRabbit    — year coerced to int in parsed_components
+    """
+
+    def setup_method(self):
+        self.guard = CitationGuard()
+
+    # Sentry HIGH — citation field
+
+    def test_citation_field_populated_on_format_valid(self):
+        """CitationResult.citation must contain the original input text (TS SDK needs it)."""
+        text = "Brown v. Board of Education, 347 U.S. 483 (1954)"
+        result = self.guard.verify(text)
+        assert result.citation == text
+
+    def test_citation_field_populated_on_format_invalid(self):
+        """citation field must be set even for invalid citations."""
+        text = "totally invalid text"
+        result = self.guard.verify(text)
+        assert result.citation == text
+
+    def test_citation_field_populated_for_fabricated(self):
+        """citation field present for fabricated-but-well-formed citations."""
+        text = "Unicorn v. Rainbow, 347 U.S. 483 (1999)"
+        result = self.guard.verify(text)
+        assert result.citation == text
+
+    # Codex P2 — deprecated 'verified' key in verify_citation_format()
+
+    def test_verify_citation_format_has_deprecated_verified_key(self):
+        """verify_citation_format() must keep 'verified' key for backward compat."""
+        result = self.guard.verify_citation_format(
+            "Brown v. Board of Education, 347 U.S. 483 (1954)"
+        )
+        assert (
+            "verified" in result
+        ), "Dropped 'verified' key breaks existing integrations that do result['verified']"
+
+    def test_verify_citation_format_deprecated_verified_equals_format_valid(self):
+        """Deprecated 'verified' == format_valid (not authority_verified)."""
+        result = self.guard.verify_citation_format(
+            "Brown v. Board of Education, 347 U.S. 483 (1954)"
+        )
+        assert result["verified"] == result["format_valid"]
+
+    def test_verify_citation_format_authority_verified_false_canonical(self):
+        """authority_verified=False remains the canonical authority field."""
+        result = self.guard.verify_citation_format(
+            "Brown v. Board of Education, 347 U.S. 483 (1954)"
+        )
+        assert result["authority_verified"] is False
+
+    # CodeRabbit MAJOR — special-char party names
+
+    def test_atandt_party_name_not_misclassified(self):
+        """AT&T in party name must not be rejected as 'Missing case name'."""
+        result = self.guard.verify(
+            "AT&T Mobility LLC v. Concepcion, 563 U.S. 333 (2011)"
+        )
+        assert (
+            result.format_valid is True
+        ), f"AT&T citation should be format_valid but got: {result.issues}"
+        assert result.status == STATUS_UNVERIFIABLE_AUTHORITY
+
+    def test_us_plaintiff_not_misclassified(self):
+        """'U.S. v. Windsor' style party name must not fail case-name check."""
+        result = self.guard.verify("U.S. v. Windsor, 570 U.S. 744 (2013)")
+        assert result.format_valid is True
+
+    def test_hyphenated_party_name_not_misclassified(self):
+        """Hyphen in party name must not fail case-name check."""
+        result = self.guard.verify("Obergefell v. Hodges, 576 U.S. 644 (2015)")
+        assert result.format_valid is True
+
+    # CodeRabbit — UK neutral citation accepted without case name
+
+    def test_uk_neutral_citation_no_case_name_required(self):
+        """UK neutral citations like [2020] UKSC 5 must pass without 'v.' party names."""
+        result = self.guard.verify("[2020] UKSC 5")
+        assert result.format_valid is True
+        assert result.citation_type == "UK_NEUTRAL"
+        assert result.status == STATUS_UNVERIFIABLE_AUTHORITY
+
+    def test_uk_neutral_year_is_int(self):
+        """Year in UK neutral citation must be coerced to int."""
+        result = self.guard.verify("[2020] UKSC 5")
+        assert result.format_valid is True
+        year = result.parsed_components.get("year")
+        assert isinstance(year, int), f"Expected year as int, got {type(year)}: {year}"
+        assert year == 2020
+
+    # CodeRabbit MINOR — year coerced to int for all patterns
+
+    def test_india_air_year_is_int(self):
+        """Year in INDIA_AIR citation must be coerced to int."""
+        result = self.guard.verify("AIR 2001 SC 3021")
+        assert result.format_valid is True
+        year = result.parsed_components.get("year")
+        assert isinstance(year, int), f"Expected year as int, got {type(year)}: {year}"
+        assert year == 2001
+
+    def test_scotus_volume_is_int(self):
+        """Volume in SCOTUS citation is still coerced to int."""
+        result = self.guard.verify("Brown v. Board of Education, 347 U.S. 483 (1954)")
+        vol = result.parsed_components.get("volume")
+        assert isinstance(vol, int)
+        assert vol == 347
+
+    # Sentry MEDIUM rejection verification — unverifiable_authority must NOT fail CI
+    # (no code test needed — this is a design decision, not a code path)
+    # The action_entrypoint.py correctly gates failure on format_invalid only.
+    # Adding a test to confirm action_entrypoint logic is unchanged would require
+    # subprocess testing; that is out of scope for unit tests.

--- a/tests/test_citation_guard.py
+++ b/tests/test_citation_guard.py
@@ -426,3 +426,33 @@ class TestCaseNamePositionCheck:
         result = self.guard.verify("123 F.3d 456 Fake v. Case")
         assert result.format_valid is False
         assert result.status == STATUS_FORMAT_INVALID
+
+
+class TestMixedCitationStatuteFallback:
+    """Sentry MEDIUM: bare case fragments must not block valid statute parsing."""
+
+    def setup_method(self):
+        self.guard = CitationGuard()
+
+    def test_bare_case_fragment_does_not_block_later_statute(self):
+        """A missing case-name fragment should not prevent statute format detection."""
+        result = self.guard.verify("347 U.S. 483 and 42 U.S.C. § 1983")
+        assert result.format_valid is True
+        assert result.status == STATUS_UNVERIFIABLE_AUTHORITY
+        assert result.citation_type == "US_CODE"
+        assert result.verified is False
+
+    def test_later_bare_case_fragment_does_not_block_earlier_statute(self):
+        """Order should not matter when a valid statute citation is present."""
+        result = self.guard.verify("42 U.S.C. § 1983 and 347 U.S. 483")
+        assert result.format_valid is True
+        assert result.status == STATUS_UNVERIFIABLE_AUTHORITY
+        assert result.citation_type == "US_CODE"
+        assert result.verified is False
+
+    def test_bare_case_without_statute_still_missing_case_name(self):
+        """The fallback must not weaken case-name enforcement for case reporters."""
+        result = self.guard.verify("347 U.S. 483")
+        assert result.format_valid is False
+        assert result.status == STATUS_FORMAT_INVALID
+        assert any("case name" in issue.lower() for issue in result.issues)

--- a/tests/test_citation_guard.py
+++ b/tests/test_citation_guard.py
@@ -1,0 +1,246 @@
+"""
+Tests for issue #17: CitationGuard must not conflate format validity with authority proof.
+
+Key invariants:
+- verified is ALWAYS False — CitationGuard has no database access
+- format_valid=True → status=unverifiable_authority, NEVER a claim of legal existence
+- Fabricated well-formed citations (Unicorn v. Rainbow) must get same treatment as real ones
+- FORMAT_INVALID for malformed, unknown reporters, missing case names
+- BatchCitationResult uses format_valid/format_invalid (not valid/invalid)
+- verify_citation_format() explicitly returns authority_verified=False
+- check_statute_citation() same semantics
+"""
+
+from qwed_legal.guards.citation_guard import (
+    CitationGuard,
+    STATUS_FORMAT_VALID,
+    STATUS_FORMAT_INVALID,
+    STATUS_UNVERIFIABLE_AUTHORITY,
+)
+
+
+class TestCitationGuardSemantics:
+    """Core semantic invariants — format ≠ authority."""
+
+    def setup_method(self):
+        self.guard = CitationGuard()
+
+    # verified is ALWAYS False
+
+    def test_verified_always_false_for_real_citation(self):
+        """verified must be False even for well-known real cases."""
+        result = self.guard.verify("Brown v. Board of Education, 347 U.S. 483 (1954)")
+        assert (
+            result.verified is False
+        ), "CitationGuard.verified must always be False — it has no database access"
+
+    def test_verified_always_false_for_fabricated_citation(self):
+        """The core bug: fabricated but well-formed citations must not be 'verified'."""
+        result = self.guard.verify("Unicorn v. Rainbow, 347 U.S. 483 (1999)")
+        assert (
+            result.verified is False
+        ), "A fabricated citation with a plausible reporter must never return verified=True"
+
+    def test_verified_always_false_for_hallucinated_citation(self):
+        """Hallucinated citation with correct reporter format must not be 'verified'."""
+        result = self.guard.verify("Nonexistent v. Case, 123 F.3d 456 (2020)")
+        assert result.verified is False
+
+    def test_verified_always_false_for_invalid_citation(self):
+        """Invalid citations must also return verified=False (not just valid ones)."""
+        result = self.guard.verify("Fake v. Case, 999 X.Y.Z. 123 (2020)")
+        assert result.verified is False
+
+    # status field semantics
+
+    def test_format_valid_citation_has_unverifiable_authority_status(self):
+        """format_valid=True must produce status=unverifiable_authority, not format_valid."""
+        result = self.guard.verify("Brown v. Board of Education, 347 U.S. 483 (1954)")
+        assert result.format_valid is True
+        assert (
+            result.status == STATUS_UNVERIFIABLE_AUTHORITY
+        ), f"Expected status=unverifiable_authority but got: {result.status}"
+
+    def test_fabricated_format_valid_citation_has_unverifiable_status(self):
+        """Fabricated but format-valid citation must carry unverifiable_authority status."""
+        result = self.guard.verify("Unicorn v. Rainbow, 347 U.S. 483 (1999)")
+        assert result.format_valid is True
+        assert result.status == STATUS_UNVERIFIABLE_AUTHORITY
+
+    def test_invalid_citation_has_format_invalid_status(self):
+        """Malformed citation must return status=format_invalid."""
+        result = self.guard.verify("Fake v. Case, 999 X.Y.Z. 123 (2020)")
+        assert result.format_valid is False
+        assert result.status == STATUS_FORMAT_INVALID
+
+    # message must state authority is unverifiable
+
+    def test_format_valid_message_states_authority_unverifiable(self):
+        """Message for format_valid=True must explicitly warn about authority."""
+        result = self.guard.verify("Brown v. Board of Education, 347 U.S. 483 (1954)")
+        assert result.format_valid is True
+        assert (
+            "UNVERIFIABLE" in result.message.upper()
+            or "AUTHORITY" in result.message.upper()
+        ), f"Expected UNVERIFIABLE/AUTHORITY in message but got: {result.message}"
+
+    def test_fabricated_citation_message_states_authority_unverifiable(self):
+        """Same warning must appear for fabricated citations."""
+        result = self.guard.verify("Unicorn v. Rainbow, 347 U.S. 483 (1999)")
+        assert (
+            "UNVERIFIABLE" in result.message.upper()
+            or "AUTHORITY" in result.message.upper()
+        )
+
+
+class TestCitationFormatValidation:
+    """Format validation still works correctly after the fix."""
+
+    def setup_method(self):
+        self.guard = CitationGuard()
+
+    def test_scotus_format_valid(self):
+        result = self.guard.verify("Brown v. Board of Education, 347 U.S. 483 (1954)")
+        assert result.format_valid is True
+        assert result.citation_type == "US_SCOTUS"
+        assert result.parsed_components.get("volume") == 347
+        assert result.parsed_components.get("reporter") == "U.S."
+
+    def test_federal_reporter_format_valid(self):
+        result = self.guard.verify("Smith v. Jones, 123 F.3d 456 (2020)")
+        assert result.format_valid is True
+        assert result.citation_type == "US_FED"
+        assert result.parsed_components.get("reporter") == "F.3d"
+
+    def test_unknown_reporter_format_invalid(self):
+        result = self.guard.verify("Fake v. Case, 999 X.Y.Z. 123 (2020)")
+        assert result.format_valid is False
+        assert result.status == STATUS_FORMAT_INVALID
+        assert any("Unknown reporter" in issue for issue in result.issues)
+
+    def test_missing_case_name_format_invalid(self):
+        result = self.guard.verify("123 U.S. 456 (1990)")
+        assert result.format_valid is False
+        assert result.status == STATUS_FORMAT_INVALID
+        assert any("case name" in issue.lower() for issue in result.issues)
+
+    def test_no_citation_format_invalid(self):
+        result = self.guard.verify("This is just plain text with no citation.")
+        assert result.format_valid is False
+        assert result.status == STATUS_FORMAT_INVALID
+
+    # backward compat
+    def test_valid_property_aliases_format_valid(self):
+        result = self.guard.verify("Brown v. Board of Education, 347 U.S. 483 (1954)")
+        assert result.valid == result.format_valid
+
+
+class TestStatuteCitationGuard:
+    """check_statute_citation: same FORMAT_ONLY semantics."""
+
+    def setup_method(self):
+        self.guard = CitationGuard()
+
+    def test_valid_statute_format(self):
+        result = self.guard.check_statute_citation("42 U.S.C. § 1983")
+        assert result.format_valid is True
+        assert result.status == STATUS_UNVERIFIABLE_AUTHORITY
+        assert result.parsed_components.get("title") == 42
+
+    def test_valid_statute_verified_always_false(self):
+        result = self.guard.check_statute_citation("42 U.S.C. § 1983")
+        assert result.verified is False
+
+    def test_invalid_statute_format_invalid(self):
+        result = self.guard.check_statute_citation("this is not a statute")
+        assert result.format_valid is False
+        assert result.status == STATUS_FORMAT_INVALID
+
+    def test_fabricated_statute_number_treated_same_as_real(self):
+        """Nonexistent section 99999 passes format check — same UNVERIFIABLE status."""
+        result = self.guard.check_statute_citation("42 U.S.C. § 99999")
+        assert result.format_valid is True
+        assert result.status == STATUS_UNVERIFIABLE_AUTHORITY
+        assert result.verified is False
+
+
+class TestVerifyCitationFormat:
+    """verify_citation_format() must explicitly expose authority_verified=False."""
+
+    def setup_method(self):
+        self.guard = CitationGuard()
+
+    def test_authority_verified_always_false_in_dict(self):
+        result = self.guard.verify_citation_format(
+            "Brown v. Board of Education, 347 U.S. 483 (1954)"
+        )
+        assert result["authority_verified"] is False
+
+    def test_authority_note_present(self):
+        result = self.guard.verify_citation_format(
+            "Brown v. Board of Education, 347 U.S. 483 (1954)"
+        )
+        assert "authority_note" in result
+        assert len(result["authority_note"]) > 0
+
+    def test_format_valid_in_dict(self):
+        result = self.guard.verify_citation_format(
+            "Brown v. Board of Education, 347 U.S. 483 (1954)"
+        )
+        assert result["format_valid"] is True
+
+    def test_status_in_dict(self):
+        result = self.guard.verify_citation_format(
+            "Brown v. Board of Education, 347 U.S. 483 (1954)"
+        )
+        assert result["status"] == STATUS_UNVERIFIABLE_AUTHORITY
+
+
+class TestBatchCitationResult:
+    """verify_batch uses format_valid/format_invalid fields."""
+
+    def setup_method(self):
+        self.guard = CitationGuard()
+
+    def test_batch_counts_are_correct(self):
+        citations = [
+            "Brown v. Board, 347 U.S. 483 (1954)",  # format_valid
+            "Invalid v. Citation, 999 FAKE 123",  # format_invalid
+        ]
+        result = self.guard.verify_batch(citations)
+        assert result.total == 2
+        assert result.format_valid == 1
+        assert result.format_invalid == 1
+
+    def test_batch_valid_alias(self):
+        """Backward-compat: result.valid == result.format_valid."""
+        citations = ["Brown v. Board, 347 U.S. 483 (1954)", "Fake v. X, 999 XYZ 1"]
+        result = self.guard.verify_batch(citations)
+        assert result.valid == result.format_valid
+
+    def test_batch_invalid_alias(self):
+        citations = ["Brown v. Board, 347 U.S. 483 (1954)", "Fake v. X, 999 XYZ 1"]
+        result = self.guard.verify_batch(citations)
+        assert result.invalid == result.format_invalid
+
+    def test_batch_verified_count_not_exposed(self):
+        """BatchCitationResult must NOT expose a 'verified' count — authority not checked."""
+        citations = ["Brown v. Board, 347 U.S. 483 (1954)"]
+        result = self.guard.verify_batch(citations)
+        assert not hasattr(result, "verified"), (
+            "BatchCitationResult must not expose a 'verified' count — "
+            "CitationGuard cannot verify authority"
+        )
+
+
+class TestStatusConstants:
+    """Status constants are importable and have correct values."""
+
+    def test_status_constants_exist(self):
+        assert STATUS_FORMAT_VALID == "format_valid"
+        assert STATUS_FORMAT_INVALID == "format_invalid"
+        assert STATUS_UNVERIFIABLE_AUTHORITY == "unverifiable_authority"
+
+    def test_format_valid_and_unverifiable_are_distinct(self):
+        """format_valid status and unverifiable_authority are separate concepts."""
+        assert STATUS_FORMAT_VALID != STATUS_UNVERIFIABLE_AUTHORITY


### PR DESCRIPTION
## Problem (Issue #17)

`CitationGuard.verify()` returns `verified=True` as soon as a citation string matches a known reporter regex pattern. Format matching is **not** authority proof.

```python
guard = CitationGuard()
result = guard.verify("Unicorn v. Rainbow, 347 U.S. 483 (1999)")
print(result.verified)  # True — fabricated case, zero authority check
```

A hallucinated-but-well-formed citation passes the guard. Downstream consumers cannot distinguish "citation format is valid" from "this legal authority exists." This violates QWED's core philosophy: if something cannot be proven, it must not be accepted.

## Root Cause

```python
# Before — verified was an alias for valid
self.verified = valid  # ← same value, stronger claim
```

The guard only runs regex matching against known reporter patterns (`U.S.`, `F.3d`, `UKSC`, etc.). It has no access to case law databases. Yet `verified=True` was returned on every pattern match.

## Changes

### `citation_guard.py` — semantic overhaul

**`CitationResult` fields:**

| Field | Before | After |
|---|---|---|
| `valid` | `True` if reporter pattern matches | Kept as backward-compat property (alias for `format_valid`) |
| `verified` | Alias for `valid` → could be `True` | Always `False` — property, not field. Cannot be `True` without DB access |
| `format_valid` | (didn't exist) | `True` if reporter pattern matches |
| `status` | (didn't exist) | `"format_valid"` / `"format_invalid"` / `"unverifiable_authority"` |
| `citation_type` | (didn't exist) | Reporter category matched (`US_SCOTUS`, `US_FED`, etc.) |
| `message` | (didn't exist) | Explains result — always states authority is unverifiable when `format_valid=True` |

**Status constants (importable):**

```python
STATUS_FORMAT_VALID           = "format_valid"
STATUS_FORMAT_INVALID         = "format_invalid"
STATUS_UNVERIFIABLE_AUTHORITY = "unverifiable_authority"  # always set when format_valid=True
```

**`verify()` result semantics:**

- `format_valid=True` → `status=unverifiable_authority` + message explicitly states:
  > "AUTHORITY UNVERIFIABLE: CitationGuard cannot confirm this case exists or is correctly identified. Format match is not proof of legal authority."
- `format_valid=False` → `status=format_invalid`

**`verify_citation_format()`** — explicit format API: returns dict with `authority_verified: False` and `authority_note` as explicit keys — callers cannot accidentally treat this as an authority check.

**`check_statute_citation()`:** Same treatment — `format_valid=True` + `status=unverifiable_authority` + `verified=False`.

**`BatchCitationResult`:** Fields renamed to `format_valid` / `format_invalid`. Backward-compat `.valid` and `.invalid` properties retained. No `verified` count exposed — authority count would be meaningless.

**Docstrings** updated at module, class, and method level:
> "FORMAT CHECKING ONLY — not authority verification"

## After the Fix

```python
guard = CitationGuard()

# Fabricated citation
result = guard.verify("Unicorn v. Rainbow, 347 U.S. 483 (1999)")
print(result.format_valid)  # True  — format matches
print(result.verified)      # False — always; no DB access
print(result.status)        # "unverifiable_authority"

# Real citation — same treatment
result = guard.verify("Brown v. Board of Education, 347 U.S. 483 (1954)")
print(result.format_valid)  # True
print(result.verified)      # False
print(result.status)        # "unverifiable_authority"

# Malformed citation
result = guard.verify("Fake v. Case, 999 X.Y.Z. 123 (2020)")
print(result.format_valid)  # False
print(result.status)        # "format_invalid"
```

## Tests — 29 new in `tests/test_citation_guard.py`

| Class | Coverage |
|---|---|
| `TestCitationGuardSemantics` | `verified` always `False` for real, fabricated, hallucinated, and invalid citations; `status=unverifiable_authority` for all `format_valid=True`; message warns about authority |
| `TestCitationFormatValidation` | SCOTUS/FED format valid; unknown reporter invalid; missing case name invalid; backward-compat `.valid` alias |
| `TestStatuteCitationGuard` | `check_statute_citation()`: format valid + `UNVERIFIABLE_AUTHORITY`; `verified=False`; fabricated section number treated same as real |
| `TestVerifyCitationFormat` | `authority_verified=False` in dict; `authority_note` present; `format_valid` and `status` in dict |
| `TestBatchCitationResult` | `format_valid`/`format_invalid` counts correct; `.valid`/`.invalid` aliases; no `verified` attribute |
| `TestStatusConstants` | Constants importable; `STATUS_FORMAT_VALID` ≠ `STATUS_UNVERIFIABLE_AUTHORITY` |

## Acceptance Criteria

* `verified` is always `False` — even for `Brown v. Board of Education`
* Fabricated `Unicorn v. Rainbow, 347 U.S. 483 (1999)` → `format_valid=True` + `verified=False`
* `status=unverifiable_authority` always set alongside `format_valid=True`
* Message explicitly states authority is unverifiable
* `verify_citation_format()` exposes `authority_verified=False` as an explicit dict key
* 166/166 tests passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Citation validation now distinguishes between format validity and authority verification status.
  * Enhanced result reporting with explicit status messages indicating unverifiable authority.
  * Improved format validation for citation components.

* **Tests**
  * Added comprehensive test coverage for citation validation and authority verification semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QWED-AI/qwed-legal/pull/28?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->