### PR TITLE
fix(clause): fail closed on non-operative keyword matches — closes #11

### DIFF
--- a/qwed_legal/guards/clause_guard.py
+++ b/qwed_legal/guards/clause_guard.py
@@ -83,15 +83,18 @@ class ClauseGuard:
             or p["is_exclusive"]
         )
         ambiguous = [p for p in propositions if p["ambiguous_termination_reference"]]
+        has_ambiguous = len(ambiguous) > 0
 
         if not conflicts:
-            if covered == 0 or ambiguous:
+            if covered == 0 or has_ambiguous:
                 caveat = (
                     "No heuristic propositions were extracted from the provided clauses."
                     if covered == 0
                     else (
-                        "One or more clauses mention termination-related language, but "
-                        "not as an operative termination right or restriction."
+                        "Some clauses contain recognised heuristic propositions, but "
+                        "one or more clauses mention termination-related language "
+                        "ambiguously rather than as an operative termination right "
+                        "or restriction."
                     )
                 )
                 return ClauseResult(

--- a/qwed_legal/guards/clause_guard.py
+++ b/qwed_legal/guards/clause_guard.py
@@ -82,16 +82,24 @@ class ClauseGuard:
             or p["min_term_days"] is not None
             or p["is_exclusive"]
         )
+        ambiguous = [p for p in propositions if p["ambiguous_termination_reference"]]
 
         if not conflicts:
-            if covered == 0:
+            if covered == 0 or ambiguous:
+                caveat = (
+                    "No heuristic propositions were extracted from the provided clauses."
+                    if covered == 0
+                    else (
+                        "One or more clauses mention termination-related language, but "
+                        "not as an operative termination right or restriction."
+                    )
+                )
                 return ClauseResult(
                     consistent=False,
                     conflicts=[],
                     status="heuristic_pass_limited",
                     message=(
-                        "HEURISTIC_PASS (LIMITED COVERAGE): No heuristic propositions "
-                        "were extracted from the provided clauses. ClauseGuard only "
+                        f"HEURISTIC_PASS (LIMITED COVERAGE): {caveat} ClauseGuard only "
                         "recognises termination, notice period, min-term, and exclusivity "
                         "patterns. The clauses may be consistent, but this guard cannot "
                         "confirm it — downstream consumers must not treat this as "
@@ -131,9 +139,13 @@ class ClauseGuard:
 
         for clause in clauses:
             lower = clause.lower()
+            can_terminate = self._has_operative_termination(lower)
             prop = {
                 "text": clause,
-                "can_terminate": self._has_termination(lower),
+                "can_terminate": can_terminate,
+                "ambiguous_termination_reference": (
+                    self._mentions_termination(lower) and not can_terminate
+                ),
                 "termination_notice_days": self._extract_days(lower, "notice"),
                 "min_term_days": self._extract_days(lower, "before"),
                 "is_exclusive": "exclusive" in lower or "only" in lower,
@@ -222,10 +234,28 @@ class ClauseGuard:
 
         return None
 
-    def _has_termination(self, text: str) -> bool:
-        """Check if clause discusses termination."""
+    def _mentions_termination(self, text: str) -> bool:
+        """Return True when text contains termination-related vocabulary."""
         terms = ["terminate", "termination", "cancel", "end the agreement"]
         return any(t in text for t in terms)
+
+    def _has_operative_termination(self, text: str) -> bool:
+        """
+        Check whether text states an operative termination right or restriction.
+
+        Raw keyword presence is not enough. For example, "may review the
+        termination process" mentions termination, but does not grant a right to
+        terminate. We only extract a termination proposition when modal/legal
+        language is tied directly to an operative verb such as terminate/cancel.
+        """
+        operative_patterns = [
+            r"\b(?:may|can|shall|must)\s+(?:not\s+)?(?:terminate|cancel)\b",
+            r"\bneither\s+party\s+may\s+(?:terminate|cancel)\b",
+            r"\b(?:allowed|entitled)\s+to\s+(?:terminate|cancel)\b",
+            r"\bright\s+to\s+(?:terminate|cancel)\b",
+            r"\b(?:may|can|shall|must)\s+(?:not\s+)?end\s+the\s+agreement\b",
+        ]
+        return any(re.search(pattern, text) for pattern in operative_patterns)
 
     def _extract_days(self, text: str, context: str) -> Optional[int]:
         """Extract number of days from text near a context word."""

--- a/tests/test_guards.py
+++ b/tests/test_guards.py
@@ -179,8 +179,10 @@ class TestClauseGuard:
                 "The buyer may not cancel this agreement during the first year.",
             ]
         )
+        assert result.consistent is False
         assert result.status == "heuristic_pass_limited"
         assert result.conflicts == []
+        assert "LIMITED COVERAGE" in result.message.upper()
 
     def test_termination_conflict_detected_in_reverse_order(self):
         """Reverse ordering should still detect the termination/minimum-term conflict."""

--- a/tests/test_guards.py
+++ b/tests/test_guards.py
@@ -156,6 +156,32 @@ class TestClauseGuard:
         # Should detect conflict between permission and prohibition
         assert result.consistent is False or len(result.conflicts) >= 0
 
+    def test_non_operative_termination_reference_not_false_conflict(self):
+        """Issue #11: keyword mentions must not become legal termination rights."""
+        guard = ClauseGuard()
+        result = guard.check_consistency(
+            [
+                "The company may review the termination process annually.",
+                "The distributor may not terminate this agreement without board approval.",
+            ]
+        )
+        assert result.consistent is False
+        assert result.status == "heuristic_pass_limited"
+        assert result.conflicts == []
+        assert "LIMITED COVERAGE" in result.message.upper()
+
+    def test_may_review_cancellation_process_not_operative_permission(self):
+        """Non-operative process-review language should fail closed, not conflict."""
+        guard = ClauseGuard()
+        result = guard.check_consistency(
+            [
+                "The buyer may review the cancellation procedure quarterly.",
+                "The buyer may not cancel this agreement during the first year.",
+            ]
+        )
+        assert result.status == "heuristic_pass_limited"
+        assert result.conflicts == []
+
     def test_termination_conflict_detected_in_reverse_order(self):
         """Reverse ordering should still detect the termination/minimum-term conflict."""
         guard = ClauseGuard()


### PR DESCRIPTION
## Problem
Closes #11.

`ClauseGuard.check_consistency()` was treating raw keyword presence as legal meaning.
For example:

```python
clauses = [
    "The company may review the termination process annually.",
    "The distributor may not terminate this agreement without board approval.",
]
```

The first clause mentions `termination`, but it does __not__ grant an operative right to terminate. It only discusses reviewing a termination process.

Before this fix, `ClauseGuard` could classify that first clause as a termination permission because it contained:
- `may`
- `termination`

Then it compared it against the second clause and returned a false conflict:

```text
Permission to terminate conflicts with prohibition on termination
```

This violated QWED's fail-closed philosophy:
- keyword presence is not legal reasoning
- non-operative language must not be treated as operative rights
- if clause meaning cannot be safely interpreted, the guard must not produce a confident legal verdict

## Root Cause

`ClauseGuard` used broad keyword checks such as:

```python
"can_terminate": self._has_termination(lower)
"is_permission": any(w in lower for w in ["may ", "can ", "allowed"])
"is_prohibition": any(w in lower for w in ["may not", "cannot", "neither", "shall not"])
```

This allowed non-operative references like `may review the termination process` to be interpreted as a termination right.

## Changes

This PR tightens termination proposition extraction.

### Added operative termination detection

`ClauseGuard` now separates:
- termination-related vocabulary detection
- operative termination right/restriction detection

New helper behavior:

```python
_mentions_termination(text)
```

Detects whether the clause merely contains termination-related vocabulary.

```python
_has_operative_termination(text)
```

Only returns true when modal/legal language is tied directly to an operative termination verb, such as:
- `may terminate`
- `may not terminate`
- `can cancel`
- `shall terminate`
- `right to terminate`
- `allowed to cancel`
- `may end the agreement`

### Added limited-coverage fallback for ambiguous termination references

If a clause mentions termination-related language but does not state an operative termination right or restriction, `ClauseGuard` now fails closed with:

```text
status = "heuristic_pass_limited"
consistent = False
conflicts = []
```

The message explicitly warns that the guard cannot confirm consistency and downstream consumers must not treat the result as verified legal reasoning.

## After the Fix

The original repro now returns limited coverage instead of a false contradiction:

```python
ClauseResult(
    consistent=False,
    conflicts=[],
    status="heuristic_pass_limited",
    message="HEURISTIC_PASS (LIMITED COVERAGE): One or more clauses mention termination-related language, but not as an operative termination right or restriction..."
)
```

This preserves QWED's principle:

> If legal meaning cannot be safely proven, do not accept it as verified.

## Tests

Added regression coverage for #11:
- `may review the termination process` is not treated as permission to terminate
- `may review the cancellation procedure` is not treated as permission to cancel
- known operative termination conflicts still remain supported

Test results:

```bash
python -m pytest tests/test_guards.py tests/test_fail_closed_guards.py -q
# 66 passed

python -m pytest -q
# 191 passed
```

## Notes

This does not claim full semantic legal reasoning. It narrows the heuristic boundary and makes ambiguous/non-operative termination language fail closed instead of producing a misleading contradiction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of termination-related language in legal clauses. The system now distinguishes between clauses that mention termination versus those with operative termination rights, providing clearer limited-coverage indicators.

* **Tests**
  * Added test cases to verify proper handling of non-operative termination language in clause consistency checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QWED-AI/qwed-legal/pull/29?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->