### PR TITLE
fix(liability): require exact cap verification — closes #19

### DIFF
--- a/qwed_legal/guards/liability_guard.py
+++ b/qwed_legal/guards/liability_guard.py
@@ -6,7 +6,7 @@ Catches percentage miscalculations, cap verification errors, and multi-tier liab
 
 from dataclasses import dataclass
 from decimal import Decimal, ROUND_HALF_UP
-from typing import List
+from typing import List, Optional
 
 
 @dataclass
@@ -51,7 +51,10 @@ class LiabilityGuard:
         Initialize LiabilityGuard.
         
         Args:
-            tolerance_percent: Tolerance for floating-point errors (default: 0.01%)
+            tolerance_percent: Deprecated compatibility argument. Liability
+                verification is exact after currency rounding; tolerance is not
+                used as a success criterion because approximate caps are not
+                legal proof.
         """
         self.tolerance = Decimal(str(tolerance_percent)) / Decimal("100")
     
@@ -59,7 +62,8 @@ class LiabilityGuard:
         self,
         contract_value: float,
         cap_percentage: float,
-        claimed_cap: float
+        claimed_cap: float,
+        tolerance_percent: Optional[float] = None,
     ) -> LiabilityResult:
         """
         Verify a simple liability cap calculation.
@@ -68,6 +72,9 @@ class LiabilityGuard:
             contract_value: Total value of the contract
             cap_percentage: Liability cap as percentage (e.g., 200 for 200%)
             claimed_cap: The cap amount claimed by the LLM
+            tolerance_percent: Deprecated compatibility argument. Ignored for
+                verification; liability caps must match exactly after currency
+                rounding unless a separate contractual rounding rule is modeled.
         
         Returns:
             LiabilityResult with verification status
@@ -78,9 +85,8 @@ class LiabilityGuard:
         
         computed = (cv * pct).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
         difference = abs(computed - claimed)
-        tolerance_amount = computed * self.tolerance
         
-        verified = difference <= tolerance_amount
+        verified = difference == Decimal("0")
         
         if verified:
             message = f"✅ VERIFIED: Liability cap of ${claimed:,.2f} is correct."
@@ -89,7 +95,8 @@ class LiabilityGuard:
                 f"❌ ERROR: Liability cap mismatch. "
                 f"{cap_percentage}% of ${contract_value:,.2f} = ${computed:,.2f}, "
                 f"but LLM claimed ${claimed:,.2f}. "
-                f"Difference: ${difference:,.2f}"
+                f"Difference: ${difference:,.2f}. "
+                "Approximate tolerance is not accepted as legal proof."
             )
         
         return LiabilityResult(
@@ -133,9 +140,8 @@ class LiabilityGuard:
         
         claimed = Decimal(str(claimed_total))
         difference = abs(total_computed - claimed)
-        tolerance_amount = total_computed * self.tolerance if total_computed > 0 else Decimal("1")
         
-        verified = difference <= tolerance_amount
+        verified = difference == Decimal("0")
         
         if verified:
             message = f"✅ VERIFIED: Total tiered liability of ${claimed:,.2f} is correct."
@@ -144,7 +150,8 @@ class LiabilityGuard:
                 f"❌ ERROR: Tiered liability mismatch. "
                 f"Computed total: ${total_computed:,.2f}, "
                 f"but LLM claimed ${claimed:,.2f}. "
-                f"Difference: ${difference:,.2f}"
+                f"Difference: ${difference:,.2f}. "
+                "Approximate tolerance is not accepted as legal proof."
             )
         
         return TieredLiabilityResult(
@@ -180,9 +187,8 @@ class LiabilityGuard:
         
         computed = (fee * mult).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
         difference = abs(computed - claimed)
-        tolerance_amount = computed * self.tolerance
         
-        verified = difference <= tolerance_amount
+        verified = difference == Decimal("0")
         
         if verified:
             message = f"✅ VERIFIED: Indemnity limit of ${claimed:,.2f} is correct."
@@ -190,7 +196,8 @@ class LiabilityGuard:
             message = (
                 f"❌ ERROR: Indemnity limit mismatch. "
                 f"{multiplier}x ${annual_fee:,.2f} = ${computed:,.2f}, "
-                f"but LLM claimed ${claimed:,.2f}."
+                f"but LLM claimed ${claimed:,.2f}. "
+                "Approximate tolerance is not accepted as legal proof."
             )
         
         return LiabilityResult(

--- a/qwed_legal/guards/liability_guard.py
+++ b/qwed_legal/guards/liability_guard.py
@@ -4,6 +4,7 @@ LiabilityGuard: Verify liability cap calculations in contracts.
 Catches percentage miscalculations, cap verification errors, and multi-tier liability issues.
 """
 
+import warnings
 from dataclasses import dataclass
 from decimal import Decimal, ROUND_HALF_UP
 from typing import List, Optional
@@ -79,6 +80,14 @@ class LiabilityGuard:
         Returns:
             LiabilityResult with verification status
         """
+        if tolerance_percent is not None:
+            warnings.warn(
+                "tolerance_percent is deprecated and ignored; liability caps "
+                "must match exactly after currency rounding",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         cv = Decimal(str(contract_value))
         pct = Decimal(str(cap_percentage)) / Decimal("100")
         claimed = Decimal(str(claimed_cap))

--- a/tests/test_guards.py
+++ b/tests/test_guards.py
@@ -1,5 +1,6 @@
 """Tests for QWED-Legal guards."""
 
+from decimal import Decimal
 from unittest.mock import patch
 
 import pytest
@@ -74,6 +75,27 @@ class TestLiabilityGuard:
         assert result.verified is False
         assert "mismatch" in result.message.lower()
 
+    def test_cap_close_enough_is_not_verified(self):
+        """Issue #19: approximate cap matches must fail closed, not verify."""
+        guard = LiabilityGuard(tolerance_percent=1.0)
+        result = guard.verify_cap(1_000_000.0, 10.0, 100_900.0)
+        assert result.verified is False
+        assert result.computed_cap == Decimal("100000.00")
+        assert result.difference == Decimal("900.00")
+        assert "tolerance is not accepted" in result.message.lower()
+
+    def test_cap_method_tolerance_argument_does_not_verify_wrong_cap(self):
+        """Deprecated method-level tolerance cannot turn an incorrect cap into proof."""
+        guard = LiabilityGuard()
+        result = guard.verify_cap(
+            contract_value=1_000_000.0,
+            cap_percentage=10.0,
+            claimed_cap=100_900.0,
+            tolerance_percent=1.0,
+        )
+        assert result.verified is False
+        assert result.difference == Decimal("900.00")
+
     def test_cap_100_percent(self):
         """Test 100% liability cap."""
         guard = LiabilityGuard()
@@ -91,6 +113,17 @@ class TestLiabilityGuard:
         result = guard.verify_tiered_liability(tiers, 1_250_000)
         assert result.verified is True
 
+    def test_tiered_liability_close_enough_is_not_verified(self):
+        """Tiered liability must also reject approximate close-enough totals."""
+        guard = LiabilityGuard(tolerance_percent=1.0)
+        result = guard.verify_tiered_liability(
+            [{"base": 1_000_000, "percentage": 10}], 100_900.0
+        )
+        assert result.verified is False
+        assert result.total_computed == Decimal("100000.00")
+        assert result.claimed_total == Decimal("100900.0")
+        assert "tolerance is not accepted" in result.message.lower()
+
     def test_indemnity_limit(self):
         """Test indemnity limit calculation (3x annual fee)."""
         guard = LiabilityGuard()
@@ -102,6 +135,15 @@ class TestLiabilityGuard:
         guard = LiabilityGuard()
         result = guard.verify_indemnity_limit(100_000, 3, 400_000)
         assert result.verified is False
+
+    def test_indemnity_limit_close_enough_is_not_verified(self):
+        """Indemnity limit verification must not accept approximate values."""
+        guard = LiabilityGuard(tolerance_percent=1.0)
+        result = guard.verify_indemnity_limit(100_000.0, 3, 300_900.0)
+        assert result.verified is False
+        assert result.computed_cap == Decimal("300000.00")
+        assert result.difference == Decimal("900.00")
+        assert "tolerance is not accepted" in result.message.lower()
 
 
 class TestClauseGuard:

--- a/tests/test_guards.py
+++ b/tests/test_guards.py
@@ -87,14 +87,31 @@ class TestLiabilityGuard:
     def test_cap_method_tolerance_argument_does_not_verify_wrong_cap(self):
         """Deprecated method-level tolerance cannot turn an incorrect cap into proof."""
         guard = LiabilityGuard()
-        result = guard.verify_cap(
-            contract_value=1_000_000.0,
-            cap_percentage=10.0,
-            claimed_cap=100_900.0,
-            tolerance_percent=1.0,
-        )
+        with pytest.warns(DeprecationWarning, match="deprecated and ignored"):
+            result = guard.verify_cap(
+                contract_value=1_000_000.0,
+                cap_percentage=10.0,
+                claimed_cap=100_900.0,
+                tolerance_percent=1.0,
+            )
         assert result.verified is False
         assert result.difference == Decimal("900.00")
+
+    def test_cap_rounds_half_up_before_exact_comparison(self):
+        """Exact verification follows modeled HALF_UP currency rounding."""
+        guard = LiabilityGuard()
+
+        exact = guard.verify_cap(Decimal("100000.005"), 100, Decimal("100000.01"))
+        assert exact.verified is True
+        assert exact.computed_cap == Decimal("100000.01")
+
+        rounded_down = guard.verify_cap(
+            Decimal("100000.005"), 100, Decimal("100000.00")
+        )
+        assert rounded_down.verified is False
+        assert rounded_down.computed_cap == Decimal("100000.01")
+        assert rounded_down.difference == Decimal("0.01")
+        assert "tolerance is not accepted" in rounded_down.message.lower()
 
     def test_cap_100_percent(self):
         """Test 100% liability cap."""


### PR DESCRIPTION
## Problem
Closes #19.

`LiabilityGuard` previously accepted approximate "close enough" cap calculations as verified legal results.
For example:

```python
from qwed_legal.guards.liability_guard import LiabilityGuard

guard = LiabilityGuard()
result = guard.verify_cap(
    contract_value=1_000_000.0,
    cap_percentage=10.0,
    claimed_cap=100_900.0,
    tolerance_percent=1.0,
)
print(result)
```

The legally computed cap is:

```text
10% of 1,000,000 = 100,000.00
```

But because the old implementation accepted values within a tolerance window, the incorrect claimed cap `100,900.00` could still return:

```text
verified=True
```

That violates QWED's verification boundary:
- approximate arithmetic is not legal proof
- a liability cap must match the derived legal calculation exactly after currency rounding
- incorrect or unproven cap values must fail closed

## Root Cause

`LiabilityGuard` used tolerance-based verification logic equivalent to:

```python
verified = difference <= tolerance_amount
```

This affected multiple liability verification paths:
- `verify_cap()`
- `verify_tiered_liability()`
- `verify_indemnity_limit()`

As a result, incorrect values could be treated as legally verified if they were numerically close enough.

## Changes

This PR changes liability verification to require an exact match after modeled currency rounding.

### Updated verification rule

The verifier now computes the legally derived amount, rounds it to cents using the existing `ROUND_HALF_UP` currency rounding, and only verifies when:

```python
difference == Decimal("0")
```

### Deprecated tolerance as proof criterion

The constructor argument remains for backward compatibility:

```python
LiabilityGuard(tolerance_percent=...)
```

And `verify_cap()` also accepts a deprecated method-level `tolerance_percent` argument so the issue repro does not crash.

However, tolerance is no longer used as a success criterion.

If a caller supplies tolerance and the claimed cap is wrong, the result fails closed.

### Improved failure messages

Mismatch messages now explicitly state:

```text
Approximate tolerance is not accepted as legal proof.
```

## After the Fix

The original repro now returns:

```python
LiabilityResult(
    verified=False,
    contract_value=Decimal("1000000.0"),
    cap_percentage=Decimal("10.0"),
    claimed_cap=Decimal("100900.0"),
    computed_cap=Decimal("100000.00"),
    difference=Decimal("900.00"),
    message="❌ ERROR: Liability cap mismatch... Approximate tolerance is not accepted as legal proof."
)
```

## Tests Added

Added regression coverage for #19:
- approximate simple cap values are not verified
- method-level tolerance cannot turn an incorrect cap into proof
- approximate tiered liability totals are not verified
- approximate indemnity limits are not verified
- exact existing valid calculations still pass

## Validation

Targeted tests:

```bash
python -m pytest tests/test_guards.py -q
# 48 passed
```

Full suite:

```bash
python -m pytest -q
# 195 passed
```

## QWED Principle Preserved

This PR ensures:

> Verification decides IF. If the exact legal calculation cannot be proven, it must not be accepted.

Approximate cap acceptance is now rejected instead of being represented as legal verification.

## Quick summary

- Fixed `qwed_legal/guards/liability_guard.py`
- Added regression tests in `tests/test_guards.py`
- Reproduced #19 before fix
- Verified exact/fail-closed behavior after fix
- Full suite green: `195 passed`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Liability cap verification now enforces exact currency rounding matches instead of accepting approximate tolerance-based values.
  * Tiered liability and indemnity limit calculations now require precise matches for compliance validation.
  * Updated all verification methods to reject approximate calculations in favor of exact matching.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QWED-AI/qwed-legal/pull/30?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->