### PR TITLE
Fix JurisdictionGuard fail-closed behavior for unresolved ambiguity

### DIFF
--- a/qwed_legal/__init__.py
+++ b/qwed_legal/__init__.py
@@ -93,9 +93,22 @@ class LegalGuard:
         """Verify a legal citation."""
         return self.citation.verify(citation)
 
-    def verify_jurisdiction(self, parties_countries: list[str], governing_law: str, forum: str = None):
+    def verify_jurisdiction(
+        self,
+        parties_countries: list[str],
+        governing_law: str,
+        forum: Optional[str] = None,
+        forum_selection: Optional[str] = None,
+        contract_type: Optional[str] = None,
+    ):
         """Verify choice of law and forum selection."""
-        return self.jurisdiction.verify_choice_of_law(parties_countries, governing_law, forum)
+        return self.jurisdiction.verify_choice_of_law(
+            parties_countries=parties_countries,
+            governing_law=governing_law,
+            forum=forum,
+            forum_selection=forum_selection,
+            contract_type=contract_type,
+        )
 
     def verify_statute_of_limitations(self, claim_type: str, jurisdiction: str, incident_date: str, filing_date: str):
         """Verify if claim is within statute of limitations."""
@@ -124,4 +137,5 @@ class LegalGuard:
     def verify_provenance(self, content: str, provenance: dict):
         """Verify AI-generated content provenance and disclosure compliance."""
         return self.provenance.verify_provenance(content, provenance)
+
 

--- a/qwed_legal/guards/jurisdiction_guard.py
+++ b/qwed_legal/guards/jurisdiction_guard.py
@@ -252,6 +252,26 @@ class JurisdictionGuard:
             return self.COUNTRY_NAMES[upper]
         return upper
 
+    def _is_non_us_country_reference(
+        self, jurisdiction: Optional[str], normalized: Optional[str]
+    ) -> bool:
+        """Check whether input explicitly names a non-US country.
+
+        This avoids treating normalized ISO country codes that collide with US
+        state abbreviations (for example, Germany -> DE) as US states.
+        """
+        if not jurisdiction or not normalized:
+            return False
+
+        upper = jurisdiction.upper().strip()
+        known_country_codes = (
+            self.COMMON_LAW_JURISDICTIONS | self.CIVIL_LAW_JURISDICTIONS
+        )
+        return (
+            (upper in self.COUNTRY_NAMES and normalized != "US")
+            or (upper in known_country_codes and upper != "US")
+        )
+
     def verify_choice_of_law(
         self,
         parties_countries: List[str],
@@ -318,16 +338,32 @@ class JurisdictionGuard:
 
         # Check 3: Forum vs governing law mismatch
         if forum_upper and governing_law_upper:
-            if self._is_us_state(governing_law_upper) and not self._is_us_jurisdiction(
+            governing_law_is_us_state = self._is_us_state(
+                governing_law_upper
+            ) and not self._is_non_us_country_reference(
+                governing_law, governing_law_upper
+            )
+            forum_is_us_state = self._is_us_state(
                 forum_upper
-            ):
+            ) and not self._is_non_us_country_reference(selected_forum, forum_upper)
+            forum_is_us_jurisdiction = self._is_us_jurisdiction(
+                forum_upper
+            ) and not self._is_non_us_country_reference(selected_forum, forum_upper)
+            governing_law_is_non_us_country = self._is_non_us_country_reference(
+                governing_law, governing_law_upper
+            )
+
+            if governing_law_is_us_state and not forum_is_us_jurisdiction:
                 conflicts.append(
                     f"Governing law '{governing_law}' (US state) but forum '{selected_forum}' is non-US. "
                     "This may create enforcement issues."
                 )
-            elif self._is_us_state(forum_upper) and not (
-                self._is_us_jurisdiction(governing_law_upper)
-                or governing_law_upper in ["US", "NY", "CA", "DE"]
+            elif forum_is_us_state and (
+                governing_law_is_non_us_country
+                or not (
+                    self._is_us_jurisdiction(governing_law_upper)
+                    or governing_law_upper in ["US", "NY", "CA", "DE"]
+                )
             ):
                 conflicts.append(
                     f"Forum '{selected_forum}' (US state) but governing law '{governing_law}' is non-US. "
@@ -367,6 +403,11 @@ class JurisdictionGuard:
             message = (
                 f"⚠️ AMBIGUOUS / UNVERIFIABLE: {len(warnings)} unresolved "
                 "jurisdiction warning(s) require legal analysis before verification."
+            )
+        elif conflicts and warnings:
+            message = (
+                f"❌ CONFLICTS DETECTED: {len(conflicts)} issue(s) found; "
+                f"⚠️ {len(warnings)} warning(s) also require review."
             )
         else:
             message = f"❌ CONFLICTS DETECTED: {len(conflicts)} issue(s) found."

--- a/qwed_legal/guards/jurisdiction_guard.py
+++ b/qwed_legal/guards/jurisdiction_guard.py
@@ -335,16 +335,19 @@ class JurisdictionGuard:
                 )
 
         # Check 4: CISG applicability warning
-        us_party = any(c in ["US"] or c in self.US_STATES for c in parties_upper)
-        foreign_party = any(
-            c not in ["US"] and c not in self.US_STATES for c in parties_upper
-        )
+        # `parties_countries` is country-level input. Do not infer US parties from
+        # US state abbreviations here because ISO country codes such as DE
+        # (Germany) and IN (India) collide with Delaware/Indiana.
+        party_country_set = set(parties_upper)
+        cross_border_parties = len(party_country_set) > 1
+        us_party = "US" in party_country_set
+        foreign_party = any(c != "US" for c in party_country_set)
         sale_of_goods = contract_type and contract_type.lower().strip() in {
             "sale_of_goods",
             "sale of goods",
             "goods",
         }
-        if (us_party and foreign_party) or (sale_of_goods and len(parties_upper) > 1):
+        if (us_party and foreign_party) or (sale_of_goods and cross_border_parties):
             warnings.append(
                 "International sale of goods may be subject to CISG unless expressly excluded."
             )

--- a/qwed_legal/guards/jurisdiction_guard.py
+++ b/qwed_legal/guards/jurisdiction_guard.py
@@ -252,6 +252,20 @@ class JurisdictionGuard:
             return self.COUNTRY_NAMES[upper]
         return upper
 
+    def _normalize_party_country(self, country: str) -> str:
+        """Normalize party-country input using country-level semantics.
+
+        Unlike jurisdiction normalization, this must not turn raw two-letter
+        country codes such as DE/IN into US states. Full US state names are
+        treated as US to avoid misclassifying domestic contracts as foreign.
+        """
+        upper = country.upper().strip()
+        if upper in self.COUNTRY_NAMES:
+            return self.COUNTRY_NAMES[upper]
+        if upper in self.US_STATE_NAMES:
+            return "US"
+        return upper
+
     def _is_non_us_country_reference(
         self, jurisdiction: Optional[str], normalized: Optional[str]
     ) -> bool:
@@ -296,7 +310,7 @@ class JurisdictionGuard:
 
         # Normalize inputs (convert full state names to abbreviations)
         governing_law_upper = self._normalize_jurisdiction(governing_law)
-        parties_upper = [self._normalize_jurisdiction(p) for p in parties_countries]
+        parties_upper = [self._normalize_party_country(p) for p in parties_countries]
         forum_upper = (
             self._normalize_jurisdiction(selected_forum) if selected_forum else None
         )

--- a/qwed_legal/guards/jurisdiction_guard.py
+++ b/qwed_legal/guards/jurisdiction_guard.py
@@ -229,6 +229,15 @@ class JurisdictionGuard:
         "DISTRICT OF COLUMBIA": "DC",
     }
 
+    COUNTRY_NAMES: Dict[str, str] = {
+        "GERMANY": "DE",
+        "INDIA": "IN",
+        "UNITED STATES": "US",
+        "UNITED STATES OF AMERICA": "US",
+        "UNITED KINGDOM": "UK",
+        "GREAT BRITAIN": "GB",
+    }
+
     def __init__(self):
         """Initialize JurisdictionGuard."""
         pass
@@ -239,6 +248,8 @@ class JurisdictionGuard:
         # If it's a full state name, convert to abbreviation
         if upper in self.US_STATE_NAMES:
             return self.US_STATE_NAMES[upper]
+        if upper in self.COUNTRY_NAMES:
+            return self.COUNTRY_NAMES[upper]
         return upper
 
     def verify_choice_of_law(
@@ -246,6 +257,8 @@ class JurisdictionGuard:
         parties_countries: List[str],
         governing_law: str,
         forum: Optional[str] = None,
+        forum_selection: Optional[str] = None,
+        contract_type: Optional[str] = None,
     ) -> JurisdictionResult:
         """
         Verify choice of law and forum selection clause.
@@ -254,18 +267,22 @@ class JurisdictionGuard:
             parties_countries: List of country codes for contract parties
             governing_law: The stated governing law (country or state)
             forum: The stated forum/venue (optional)
-            jurisdiction_type: Type of jurisdiction clause
+            forum_selection: Alias for forum, kept for compatibility with callers
+            contract_type: Optional contract type for convention-specific checks
 
         Returns:
             JurisdictionResult with verification status and any conflicts
         """
         conflicts = []
         warnings = []
+        selected_forum = forum if forum is not None else forum_selection
 
         # Normalize inputs (convert full state names to abbreviations)
         governing_law_upper = self._normalize_jurisdiction(governing_law)
-        parties_upper = [p.upper().strip() for p in parties_countries]
-        forum_upper = self._normalize_jurisdiction(forum) if forum else None
+        parties_upper = [self._normalize_jurisdiction(p) for p in parties_countries]
+        forum_upper = (
+            self._normalize_jurisdiction(selected_forum) if selected_forum else None
+        )
 
         # Check 1: Is governing law a recognized jurisdiction?
         if not self._is_valid_jurisdiction(governing_law_upper):
@@ -305,7 +322,7 @@ class JurisdictionGuard:
                 forum_upper
             ):
                 conflicts.append(
-                    f"Governing law '{governing_law}' (US state) but forum '{forum}' is non-US. "
+                    f"Governing law '{governing_law}' (US state) but forum '{selected_forum}' is non-US. "
                     "This may create enforcement issues."
                 )
             elif self._is_us_state(forum_upper) and not (
@@ -313,7 +330,7 @@ class JurisdictionGuard:
                 or governing_law_upper in ["US", "NY", "CA", "DE"]
             ):
                 conflicts.append(
-                    f"Forum '{forum}' (US state) but governing law '{governing_law}' is non-US. "
+                    f"Forum '{selected_forum}' (US state) but governing law '{governing_law}' is non-US. "
                     "Consider alignment for enforceability."
                 )
 
@@ -322,7 +339,12 @@ class JurisdictionGuard:
         foreign_party = any(
             c not in ["US"] and c not in self.US_STATES for c in parties_upper
         )
-        if us_party and foreign_party:
+        sale_of_goods = contract_type and contract_type.lower().strip() in {
+            "sale_of_goods",
+            "sale of goods",
+            "goods",
+        }
+        if (us_party and foreign_party) or (sale_of_goods and len(parties_upper) > 1):
             warnings.append(
                 "International sale of goods may be subject to CISG unless expressly excluded."
             )
@@ -334,10 +356,15 @@ class JurisdictionGuard:
                 "Consider a neutral jurisdiction for balance."
             )
 
-        verified = len(conflicts) == 0
+        verified = len(conflicts) == 0 and len(warnings) == 0
 
         if verified:
             message = "✅ VERIFIED: Jurisdiction clause appears consistent."
+        elif warnings and not conflicts:
+            message = (
+                f"⚠️ AMBIGUOUS / UNVERIFIABLE: {len(warnings)} unresolved "
+                "jurisdiction warning(s) require legal analysis before verification."
+            )
         else:
             message = f"❌ CONFLICTS DETECTED: {len(conflicts)} issue(s) found."
 
@@ -346,7 +373,7 @@ class JurisdictionGuard:
             conflicts=conflicts,
             warnings=warnings,
             governing_law=governing_law,
-            forum=forum,
+            forum=selected_forum,
             message=message,
         )
 

--- a/qwed_legal/guards/jurisdiction_guard.py
+++ b/qwed_legal/guards/jurisdiction_guard.py
@@ -400,7 +400,22 @@ class JurisdictionGuard:
             )
 
         # Check 5: Neutral jurisdiction suggestion
-        if len(parties_upper) >= 2 and governing_law_upper in parties_upper:
+        # Compare governing law to party countries using country-level semantics.
+        # US state laws (e.g., Delaware -> DE) should match US parties, not
+        # foreign party country codes that collide with state abbreviations
+        # (e.g., Germany -> DE, India -> IN).
+        governing_law_is_us_party_jurisdiction = self._is_us_jurisdiction(
+            governing_law_upper
+        ) and not self._is_non_us_country_reference(
+            governing_law, governing_law_upper
+        )
+        governing_law_matches_party_country = (
+            governing_law_is_us_party_jurisdiction and "US" in parties_upper
+        ) or (
+            not governing_law_is_us_party_jurisdiction
+            and governing_law_upper in parties_upper
+        )
+        if cross_border_parties and governing_law_matches_party_country:
             warnings.append(
                 f"Governing law '{governing_law}' favors one party's home jurisdiction. "
                 "Consider a neutral jurisdiction for balance."

--- a/qwed_legal/guards/jurisdiction_guard.py
+++ b/qwed_legal/guards/jurisdiction_guard.py
@@ -264,13 +264,10 @@ class JurisdictionGuard:
             return False
 
         upper = jurisdiction.upper().strip()
-        known_country_codes = (
-            self.COMMON_LAW_JURISDICTIONS | self.CIVIL_LAW_JURISDICTIONS
-        )
-        return (
-            (upper in self.COUNTRY_NAMES and normalized != "US")
-            or (upper in known_country_codes and upper != "US")
-        )
+        # Only full country names are unambiguous here. Raw two-letter values
+        # such as "DE" may mean either Germany or Delaware depending on context,
+        # so keep those eligible for US-state checks in governing-law/forum logic.
+        return upper in self.COUNTRY_NAMES and normalized != "US"
 
     def verify_choice_of_law(
         self,

--- a/tests/test_fail_closed_guards.py
+++ b/tests/test_fail_closed_guards.py
@@ -413,3 +413,38 @@ class TestJurisdictionGuardFailClosed:
         assert result.verified is True
         assert result.conflicts == []
         assert not any("CISG" in warning for warning in result.warnings)
+
+    def test_governing_law_country_code_not_treated_as_us_state(self):
+        """DE as Germany must not be treated as Delaware in mismatch checks."""
+        result = self.guard.verify_choice_of_law(
+            parties_countries=["FR", "IT"],
+            governing_law="DE",
+            forum="London",
+        )
+
+        assert result.conflicts == []
+        assert not any("US state" in conflict for conflict in result.conflicts)
+
+    def test_governing_law_country_name_not_treated_as_us_state(self):
+        """Germany normalizes to DE but must remain a country reference."""
+        result = self.guard.verify_choice_of_law(
+            parties_countries=["FR", "IT"],
+            governing_law="Germany",
+            forum="London",
+        )
+
+        assert result.conflicts == []
+        assert not any("US state" in conflict for conflict in result.conflicts)
+
+    def test_conflict_message_includes_warning_count_when_both_exist(self):
+        """Summary message should mention warnings when conflicts also exist."""
+        result = self.guard.verify_choice_of_law(
+            parties_countries=["US", "UK"],
+            governing_law="Delaware",
+            forum="London",
+        )
+
+        assert result.conflicts
+        assert result.warnings
+        assert "CONFLICTS DETECTED" in result.message
+        assert "warning" in result.message.lower()

--- a/tests/test_fail_closed_guards.py
+++ b/tests/test_fail_closed_guards.py
@@ -360,3 +360,31 @@ class TestJurisdictionGuardFailClosed:
         assert "ATLANTIS" in warning_text or any(
             "unrecognized" in w.lower() for w in result.warnings
         )
+
+    def test_choice_of_law_warnings_fail_closed(self):
+        """Issue #16: warning-only ambiguity must not return verified=True."""
+        result = self.guard.verify_choice_of_law(
+            parties_countries=["Germany", "India"],
+            governing_law="New York",
+            forum_selection="New York",
+            contract_type="sale_of_goods",
+        )
+
+        assert result.verified is False
+        assert result.conflicts == []
+        assert result.warnings
+        assert "UNVERIFIABLE" in result.message
+        assert "VERIFIED" not in result.message
+
+    def test_cross_border_legal_system_warning_blocks_verification(self):
+        """Known cross-system parties are ambiguous unless further legal analysis resolves them."""
+        result = self.guard.verify_choice_of_law(
+            parties_countries=["DE", "IN"],
+            governing_law="New York",
+            forum="New York",
+        )
+
+        assert result.verified is False
+        assert result.conflicts == []
+        assert any("different legal systems" in warning for warning in result.warnings)
+        assert "AMBIGUOUS" in result.message

--- a/tests/test_fail_closed_guards.py
+++ b/tests/test_fail_closed_guards.py
@@ -388,3 +388,28 @@ class TestJurisdictionGuardFailClosed:
         assert result.conflicts == []
         assert any("different legal systems" in warning for warning in result.warnings)
         assert "AMBIGUOUS" in result.message
+
+    def test_country_code_state_collision_does_not_hide_foreign_party(self):
+        """DE/IN country codes must not be treated as Delaware/Indiana parties."""
+        result = self.guard.verify_choice_of_law(
+            parties_countries=["US", "Germany"],
+            governing_law="New York",
+        )
+
+        assert result.verified is False
+        assert result.conflicts == []
+        assert any("CISG" in warning for warning in result.warnings)
+        assert "UNVERIFIABLE" in result.message
+
+    def test_domestic_sale_of_goods_does_not_trigger_international_warning(self):
+        """Domestic sale-of-goods contracts must not receive a CISG warning."""
+        result = self.guard.verify_choice_of_law(
+            parties_countries=["US", "US"],
+            governing_law="New York",
+            forum="New York",
+            contract_type="sale_of_goods",
+        )
+
+        assert result.verified is True
+        assert result.conflicts == []
+        assert not any("CISG" in warning for warning in result.warnings)

--- a/tests/test_fail_closed_guards.py
+++ b/tests/test_fail_closed_guards.py
@@ -451,6 +451,24 @@ class TestJurisdictionGuardFailClosed:
         assert result.conflicts == []
         assert not any("US state" in conflict for conflict in result.conflicts)
 
+    def test_state_law_does_not_match_colliding_party_country_code(self):
+        """US state laws must not match colliding foreign party country codes."""
+        delaware_result = self.guard.verify_choice_of_law(
+            parties_countries=["DE", "FR"],
+            governing_law="Delaware",
+            forum="Delaware",
+        )
+        indiana_result = self.guard.verify_choice_of_law(
+            parties_countries=["IN", "GB"],
+            governing_law="Indiana",
+            forum="Indiana",
+        )
+
+        for result in [delaware_result, indiana_result]:
+            assert result.verified is True
+            assert result.conflicts == []
+            assert not any("favors one party" in warning for warning in result.warnings)
+
     def test_conflict_message_includes_warning_count_when_both_exist(self):
         """Summary message should mention warnings when conflicts also exist."""
         result = self.guard.verify_choice_of_law(

--- a/tests/test_fail_closed_guards.py
+++ b/tests/test_fail_closed_guards.py
@@ -414,16 +414,15 @@ class TestJurisdictionGuardFailClosed:
         assert result.conflicts == []
         assert not any("CISG" in warning for warning in result.warnings)
 
-    def test_governing_law_country_code_not_treated_as_us_state(self):
-        """DE as Germany must not be treated as Delaware in mismatch checks."""
+    def test_ambiguous_de_code_still_supports_delaware_mismatch_check(self):
+        """Raw DE is ambiguous and must still support Delaware mismatch checks."""
         result = self.guard.verify_choice_of_law(
             parties_countries=["FR", "IT"],
             governing_law="DE",
             forum="London",
         )
 
-        assert result.conflicts == []
-        assert not any("US state" in conflict for conflict in result.conflicts)
+        assert any("US state" in conflict for conflict in result.conflicts)
 
     def test_governing_law_country_name_not_treated_as_us_state(self):
         """Germany normalizes to DE but must remain a country reference."""

--- a/tests/test_fail_closed_guards.py
+++ b/tests/test_fail_closed_guards.py
@@ -414,8 +414,24 @@ class TestJurisdictionGuardFailClosed:
         assert result.conflicts == []
         assert not any("CISG" in warning for warning in result.warnings)
 
+    def test_party_country_normalization_does_not_treat_states_as_foreign(self):
+        """State names in party-country input must not become India/Germany."""
+        result = self.guard.verify_choice_of_law(
+            parties_countries=["Indiana", "Delaware"],
+            governing_law="New York",
+            forum="New York",
+            contract_type="sale_of_goods",
+        )
+
+        assert result.verified is True
+        assert result.conflicts == []
+        assert not result.warnings
+
     def test_ambiguous_de_code_still_supports_delaware_mismatch_check(self):
         """Raw DE is ambiguous and must still support Delaware mismatch checks."""
+        # Raw "DE" can mean Delaware or Germany. In governing-law context, keep
+        # it eligible for US-state handling. Non-US parties avoid CISG noise so
+        # the assertion focuses on the forum/governing-law mismatch message.
         result = self.guard.verify_choice_of_law(
             parties_countries=["FR", "IT"],
             governing_law="DE",

--- a/tests/test_guards.py
+++ b/tests/test_guards.py
@@ -409,6 +409,21 @@ class TestLegalGuard:
             "HEURISTIC" in result.message.upper() or "LIMITED" in result.message.upper()
         )
 
+    def test_verify_jurisdiction_passes_new_optional_arguments(self):
+        """LegalGuard wrapper must expose JurisdictionGuard's full public API."""
+        guard = LegalGuard()
+        result = guard.verify_jurisdiction(
+            parties_countries=["Germany", "India"],
+            governing_law="New York",
+            forum_selection="New York",
+            contract_type="sale_of_goods",
+        )
+
+        assert result.verified is False
+        assert result.forum == "New York"
+        assert result.warnings
+        assert "UNVERIFIABLE" in result.message
+
 
 class TestJurisdictionGuard:
     """Test JurisdictionGuard functionality."""

--- a/tests/test_guards.py
+++ b/tests/test_guards.py
@@ -420,6 +420,7 @@ class TestLegalGuard:
         )
 
         assert result.verified is False
+        assert result.conflicts == []
         assert result.forum == "New York"
         assert result.warnings
         assert "UNVERIFIABLE" in result.message


### PR DESCRIPTION
## Summary
Closes #16

This PR updates `JurisdictionGuard.verify_choice_of_law()` so jurisdiction results no longer return `verified=True` when the guard itself has surfaced unresolved legal ambiguity through warnings.

Previously, choice-of-law verification used conflict-only logic:

```python
verified = len(conflicts) == 0
```

That allowed warning-only ambiguity, such as cross-border legal-system uncertainty or CISG applicability concerns, to still produce a verified result.

This PR changes the verification boundary to fail closed:

```python
verified = len(conflicts) == 0 and len(warnings) == 0
```

## Changes

- Fail closed when jurisdiction warnings remain unresolved.
- Return explicit `AMBIGUOUS / UNVERIFIABLE` messaging for warning-only results.
- Add `forum_selection` as a compatibility alias for `forum`.
- Add optional `contract_type` handling for convention-related checks such as `sale_of_goods`.
- Normalize common country names used in issue repros:
  - `Germany -> DE`
  - `India -> IN`
  - `United States -> US`
  - `United Kingdom -> UK`
- Add regression tests for:
  - the exact #16 warning-only ambiguity scenario
  - known cross-system parties producing ambiguity and blocking verification

## Why

QWED legal verification should not treat unresolved legal ambiguity as proof.

If a jurisdiction result includes warnings such as:
- cross-border legal-system mismatch
- convention applicability concerns
- incomplete jurisdiction analysis
- unresolved conflict-of-laws complexity

then the result should not be reported as verified.

This aligns the guard with QWED's fail-closed principle:

> If something cannot be proven, it must not be accepted.

## Tests

```bash
python -m pytest tests/test_fail_closed_guards.py tests/test_guards.py -q
```

Result:

```text
73 passed
```

```bash
python -m pytest -q
```

Result:

```text
198 passed
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Warnings-only situations now yield an unverifiable result (verified = false) with clear summary text.
  * Conflict messages consistently reference the resolved forum selection shown to users.

* **New Features**
  * Improved country-name normalization to avoid state/country collisions and improve jurisdiction detection.
  * Optional contract-type refines international-sales (CISG) warnings for sale-of-goods and mixed-party scenarios.

* **Tests**
  * Expanded coverage for warnings, cross-border ambiguity, normalization edge cases, and combined conflicts+warnings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QWED-AI/qwed-legal/pull/31?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->