### PR TITLE
fix(irac): enforce fail-closed verification boundary for issue #12

### DIFF
--- a/qwed_legal/guards/irac_guard.py
+++ b/qwed_legal/guards/irac_guard.py
@@ -110,7 +110,9 @@ class IRACGuard:
     _MIN_RULE_WORDS_FOR_OVERLAP = 4
 
     def __init__(self) -> None:
-        self._compiled = {k: re.compile(v, re.DOTALL) for k, v in self._SECTION_PATTERNS.items()}
+        self._compiled = {
+            k: re.compile(v, re.DOTALL) for k, v in self._SECTION_PATTERNS.items()
+        }
 
     def verify_structure(self, text: str) -> dict:
         result = self.verify(text)
@@ -220,7 +222,9 @@ class IRACGuard:
 
         rule_text = components.get("rule", "")
         app_text = components.get("application", "").lower()
-        rule_words = rule_text.lower().split()
+        import re as _re
+
+        rule_words = _re.findall(r"\b\w+\b", rule_text.lower())
         rule_keywords = [w for w in rule_words if len(w) >= self._MIN_KEYWORD_LEN]
 
         if len(rule_keywords) >= self._MIN_RULE_WORDS_FOR_OVERLAP:

--- a/qwed_legal/guards/irac_guard.py
+++ b/qwed_legal/guards/irac_guard.py
@@ -1,58 +1,231 @@
+"""
+IRACGuard: Validate IRAC legal reasoning structure.
+
+IMPORTANT — scope of this guard:
+  IRACGuard checks whether a legal analysis text contains the four required
+  IRAC components (Issue, Rule, Application, Conclusion) AND performs
+  structural coherence checks between them.
+
+  Structural validity is NOT reasoning validity:
+  - A text with all four headings may contain logically invalid reasoning.
+  - A hallucinated rule or fabricated conclusion still passes structural checks.
+  - This guard has no access to legal databases and cannot verify that:
+      * the cited rule exists or is correctly stated
+      * the application logically follows from the rule
+      * the conclusion is legally sound
+
+  Consumers MUST treat IRACGuard results as STRUCTURE_VALID / STRUCTURE_INVALID,
+  never as VERIFIED legal reasoning. The status field makes this explicit:
+
+    status="structure_invalid"         — one or more IRAC sections missing
+    status="coherence_invalid"         — sections present but structurally incoherent
+    status="unverifiable_reasoning"    — structure and coherence pass; reasoning
+                                         correctness cannot be proven without
+                                         a legal knowledge base
+
+  A status of "unverifiable_reasoning" does NOT mean the legal analysis is
+  correct. Reasoning verification requires external legal authority validation.
+"""
+
 import re
-from typing import Dict, Any
+from dataclasses import dataclass, field
+from typing import Dict, List, Tuple
+
+# Status constants
+STATUS_STRUCTURE_INVALID = "structure_invalid"
+STATUS_COHERENCE_INVALID = "coherence_invalid"
+# Always set when structure + coherence pass. Reasoning correctness cannot
+# be proven by regex/heuristic means. This is the normal passing state.
+STATUS_UNVERIFIABLE_REASONING = "unverifiable_reasoning"
+
+
+@dataclass
+class IRACResult:
+    """
+    Result of an IRAC structure check.
+
+    Fields:
+        structure_valid   - True if all four IRAC sections are present and
+                            coherence checks pass. Does NOT mean the reasoning
+                            is legally sound.
+        status            - one of STATUS_STRUCTURE_INVALID,
+                            STATUS_COHERENCE_INVALID, or
+                            STATUS_UNVERIFIABLE_REASONING.
+        components        - extracted text for each IRAC section.
+        missing_sections  - list of IRAC sections not found in the text.
+        coherence_issues  - list of structural coherence problems detected.
+        message           - human-readable explanation of the result.
+    """
+
+    structure_valid: bool
+    status: str
+    components: Dict[str, str] = field(default_factory=dict)
+    missing_sections: List[str] = field(default_factory=list)
+    coherence_issues: List[str] = field(default_factory=list)
+    message: str = ""
+
+    @property
+    def verified(self) -> bool:
+        """
+        Always False.
+
+        IRACGuard cannot verify legal reasoning correctness — it has no access
+        to legal authority databases. Returning True here would be a false
+        claim of reasoning proof. Use structure_valid to check structural
+        presence only.
+        """
+        return False
+
 
 class IRACGuard:
     """
-    Verifies that legal reasoning follows the IRAC framework (Issue, Rule, Application, Conclusion).
-    Source: Enforces 'Reasoned Elaboration' standards from MSLR Benchmark.
+    Validate that a legal analysis text follows the IRAC framework.
+
+    Scope: STRUCTURAL CHECKING + BASIC COHERENCE ONLY.
+
+    This guard does NOT:
+    - Confirm that a cited rule exists in any legal database.
+    - Verify that the application logically follows from the rule.
+    - Validate that the conclusion is legally sound.
+    - Detect hallucinated rules, fabricated cases, or invalid legal logic.
+
+    An IRACResult with structure_valid=True means: the text CONTAINS the four
+    required IRAC sections and passes basic coherence checks. It does not mean:
+    the legal reasoning is valid.
+
+    Downstream consumers MUST check result.status to distinguish:
+      STATUS_UNVERIFIABLE_REASONING  -> structure ok; reasoning unproven
+      STATUS_COHERENCE_INVALID       -> sections present but structurally incoherent
+      STATUS_STRUCTURE_INVALID       -> one or more sections missing
     """
-    def __init__(self):
-        # Regex patterns to detect the 4 pillars of legal logic
-        self.patterns = {
-            "issue": r"(?i)(issue|question presented|legal problem):?\s*(.*)",
-            "rule": r"(?i)(rule|law|statute|legal principle):?\s*(.*)",
-            "application": r"(?i)(application|analysis|reasoning|applying the law):?\s*(.*)",
-            "conclusion": r"(?i)(conclusion|holding|verdict):?\s*(.*)"
+
+    _SECTION_PATTERNS: Dict[str, str] = {
+        "issue": r"(?i)(?:issue|question presented|legal problem)\s*:?\s*(.*)",
+        "rule": r"(?i)(?:rule|law|statute|legal principle)\s*:?\s*(.*)",
+        "application": r"(?i)(?:application|analysis|reasoning|applying the law)\s*:?\s*(.*)",
+        "conclusion": r"(?i)(?:conclusion|holding|verdict)\s*:?\s*(.*)",
+    }
+
+    _MIN_KEYWORD_LEN = 4
+    _MIN_RULE_WORDS_FOR_OVERLAP = 4
+
+    def __init__(self) -> None:
+        self._compiled = {
+            k: re.compile(v) for k, v in self._SECTION_PATTERNS.items()
         }
 
-    def verify_structure(self, llm_output: str) -> Dict[str, Any]:
-        components = {}
-        missing_steps = []
-        
-        # 1. Structural Verification: Does the reasoning path exist?
-        for step, pattern in self.patterns.items():
-            match = re.search(pattern, llm_output)
+    def verify_structure(self, text: str) -> IRACResult:
+        """
+        Check whether text contains all four IRAC sections and passes
+        basic structural coherence checks.
+
+        Returns IRACResult with:
+          structure_valid=True  + status=STATUS_UNVERIFIABLE_REASONING
+              when all sections present and coherence checks pass.
+              WARNING: does NOT confirm the reasoning is legally valid.
+
+          structure_valid=False + status=STATUS_STRUCTURE_INVALID
+              when one or more IRAC sections are missing.
+
+          structure_valid=False + status=STATUS_COHERENCE_INVALID
+              when all sections present but structurally incoherent.
+
+        Reasoning correctness is ALWAYS unverifiable. A nonsensical analysis
+        like "Rule: The sky is always green" passes if formatted as IRAC.
+        """
+        components, missing = self._extract_sections(text)
+
+        if missing:
+            return IRACResult(
+                structure_valid=False,
+                status=STATUS_STRUCTURE_INVALID,
+                components=components,
+                missing_sections=missing,
+                message=(
+                    f"STRUCTURE INVALID: Missing IRAC section(s): "
+                    f"{', '.join(missing)}. Legal analysis must contain "
+                    f"Issue, Rule, Application, and Conclusion."
+                ),
+            )
+
+        coherence_issues = self._check_coherence(components)
+        if coherence_issues:
+            return IRACResult(
+                structure_valid=False,
+                status=STATUS_COHERENCE_INVALID,
+                components=components,
+                coherence_issues=coherence_issues,
+                message=(
+                    f"COHERENCE INVALID: All IRAC sections present but "
+                    f"structurally incoherent. "
+                    f"Issues: {'; '.join(coherence_issues)}. "
+                    f"NOTE: Even coherent structure does not prove the "
+                    f"reasoning is legally correct."
+                ),
+            )
+
+        return IRACResult(
+            structure_valid=True,
+            status=STATUS_UNVERIFIABLE_REASONING,
+            components=components,
+            message=(
+                "STRUCTURE VALID: All four IRAC sections present and "
+                "structurally coherent. "
+                "REASONING UNVERIFIABLE: IRACGuard cannot confirm the cited "
+                "rule exists, the application is logically sound, or the "
+                "conclusion is legally correct. Structure check is not proof "
+                "of valid legal reasoning."
+            ),
+        )
+
+    def _extract_sections(
+        self, text: str
+    ) -> Tuple[Dict[str, str], List[str]]:
+        """Extract IRAC section content. Returns (components, missing_sections)."""
+        components: Dict[str, str] = {}
+        missing: List[str] = []
+        for section, pattern in self._compiled.items():
+            match = pattern.search(text)
             if match:
-                components[step] = match.group(2).strip()
+                components[section] = match.group(1).strip()
             else:
-                missing_steps.append(step)
-        
-        if missing_steps:
-            return {
-                "verified": False,
-                "error": f"Failed Reasoned Elaboration. Missing steps: {', '.join(missing_steps)}. Legal advice must follow IRAC structure.",
-                "missing": missing_steps
-            }
+                missing.append(section)
+        return components, missing
 
-        # 2. Heuristic Check: Application must reference the Rule
-        # MSLR notes that reasoning often fails at the application stage.
-        rule_keywords = set(components["rule"].lower().split())
-        app_text = components["application"].lower()
-        
-        # Simple overlap check to ensure Application is actually discussing the Rule
-        # Filter short words to reduce noise
-        overlap = [w for w in rule_keywords if w in app_text and len(w) > 4]
-        
-        # If rule is very short, we skip this heuristic to avoid false positives
-        if len(rule_keywords) > 3 and len(overlap) < 1:
-             return {
-                "verified": False,
-                "error": "Logical Disconnect: The 'Application' section does not appear to apply the cited 'Rule'.",
-                "risk": "Hallucinated Reasoning"
-            }
+    def _check_coherence(self, components: Dict[str, str]) -> List[str]:
+        """
+        Run structural coherence checks on extracted IRAC sections.
 
-        return {
-            "verified": True,
-            "components": components,
-            "note": "IRAC structure confirmed. Reasoning trace is structurally valid."
-        }
+        Returns list of coherence issue descriptions (empty = coherent).
+
+        Checks:
+          1. Non-empty sections: each section must have substantive content.
+          2. Rule-Application keyword overlap: Application must reference at
+             least one meaningful keyword from the Rule. Structural signal only
+             — does not validate logical soundness.
+        """
+        issues: List[str] = []
+
+        for section, content in components.items():
+            if not content:
+                issues.append(
+                    f"'{section}' section heading found but has no content."
+                )
+
+        rule_text = components.get("rule", "")
+        app_text = components.get("application", "").lower()
+        rule_words = rule_text.lower().split()
+        rule_keywords = [w for w in rule_words if len(w) >= self._MIN_KEYWORD_LEN]
+
+        if len(rule_words) >= self._MIN_RULE_WORDS_FOR_OVERLAP:
+            overlap = [w for w in rule_keywords if w in app_text]
+            if not overlap:
+                issues.append(
+                    "Application section shares no meaningful keywords with "
+                    "the Rule section. The application may be structurally "
+                    "disconnected from the stated rule. NOTE: keyword overlap "
+                    "is a structural signal only — it does not prove the "
+                    "application is logically valid."
+                )
+
+        return issues

--- a/qwed_legal/guards/irac_guard.py
+++ b/qwed_legal/guards/irac_guard.py
@@ -100,10 +100,10 @@ class IRACGuard:
     """
 
     _SECTION_PATTERNS: Dict[str, str] = {
-        "issue": r"(?im)^\s*(?:\*\*?)?(?:issue|question presented|legal problem)(?:\*\*?)?\s*:?\s*\n?(.*?)(?=(?:\n\s*(?:\*\*?)?(?:rule|law|statute|legal principle|application|analysis|reasoning|applying the law|conclusion|holding|verdict)(?:\*\*?)?\s*:)|$)",
-        "rule": r"(?im)^\s*(?:\*\*?)?(?:rule|law|statute|legal principle)(?:\*\*?)?\s*:?\s*\n?(.*?)(?=(?:\n\s*(?:\*\*?)?(?:issue|question presented|legal problem|application|analysis|reasoning|applying the law|conclusion|holding|verdict)(?:\*\*?)?\s*:)|$)",
-        "application": r"(?im)^\s*(?:\*\*?)?(?:application|analysis|reasoning|applying the law)(?:\*\*?)?\s*:?\s*\n?(.*?)(?=(?:\n\s*(?:\*\*?)?(?:issue|question presented|legal problem|rule|law|statute|legal principle|conclusion|holding|verdict)(?:\*\*?)?\s*:)|$)",
-        "conclusion": r"(?im)^\s*(?:\*\*?)?(?:conclusion|holding|verdict)(?:\*\*?)?\s*:?\s*\n?(.*?)(?=(?:\n\s*(?:\*\*?)?(?:issue|question presented|legal problem|rule|law|statute|legal principle|application|analysis|reasoning|applying the law)(?:\*\*?)?\s*:)|$)",
+        "issue": r"(?im)^\s*(?:\*\*?)?(?:issue|question presented|legal problem)(?:\*\*?)?\s*:?\s*\n?(.*?)(?=(?:\n\s*(?:\*\*?)?(?:rule|law|statute|legal principle|application|analysis|reasoning|applying the law|conclusion|holding|verdict)(?:\*\*?)?\s*:)|\Z)",
+        "rule": r"(?im)^\s*(?:\*\*?)?(?:rule|law|statute|legal principle)(?:\*\*?)?\s*:?\s*\n?(.*?)(?=(?:\n\s*(?:\*\*?)?(?:issue|question presented|legal problem|application|analysis|reasoning|applying the law|conclusion|holding|verdict)(?:\*\*?)?\s*:)|\Z)",
+        "application": r"(?im)^\s*(?:\*\*?)?(?:application|analysis|reasoning|applying the law)(?:\*\*?)?\s*:?\s*\n?(.*?)(?=(?:\n\s*(?:\*\*?)?(?:issue|question presented|legal problem|rule|law|statute|legal principle|conclusion|holding|verdict)(?:\*\*?)?\s*:)|\Z)",
+        "conclusion": r"(?im)^\s*(?:\*\*?)?(?:conclusion|holding|verdict)(?:\*\*?)?\s*:?\s*\n?(.*?)(?=(?:\n\s*(?:\*\*?)?(?:issue|question presented|legal problem|rule|law|statute|legal principle|application|analysis|reasoning|applying the law)(?:\*\*?)?\s*:)|\Z)",
     }
 
     _MIN_KEYWORD_LEN = 4

--- a/qwed_legal/guards/irac_guard.py
+++ b/qwed_legal/guards/irac_guard.py
@@ -100,21 +100,31 @@ class IRACGuard:
     """
 
     _SECTION_PATTERNS: Dict[str, str] = {
-        "issue": r"(?i)(?:issue|question presented|legal problem)\s*:?\s*(.*)",
-        "rule": r"(?i)(?:rule|law|statute|legal principle)\s*:?\s*(.*)",
-        "application": r"(?i)(?:application|analysis|reasoning|applying the law)\s*:?\s*(.*)",
-        "conclusion": r"(?i)(?:conclusion|holding|verdict)\s*:?\s*(.*)",
+        "issue": r"(?im)^\s*(?:\*\*?)?(?:issue|question presented|legal problem)(?:\*\*?)?\s*:?\s*\n?(.*?)(?=(?:\n\s*(?:\*\*?)?(?:rule|law|statute|legal principle|application|analysis|reasoning|applying the law|conclusion|holding|verdict)(?:\*\*?)?\s*:)|$)",
+        "rule": r"(?im)^\s*(?:\*\*?)?(?:rule|law|statute|legal principle)(?:\*\*?)?\s*:?\s*\n?(.*?)(?=(?:\n\s*(?:\*\*?)?(?:issue|question presented|legal problem|application|analysis|reasoning|applying the law|conclusion|holding|verdict)(?:\*\*?)?\s*:)|$)",
+        "application": r"(?im)^\s*(?:\*\*?)?(?:application|analysis|reasoning|applying the law)(?:\*\*?)?\s*:?\s*\n?(.*?)(?=(?:\n\s*(?:\*\*?)?(?:issue|question presented|legal problem|rule|law|statute|legal principle|conclusion|holding|verdict)(?:\*\*?)?\s*:)|$)",
+        "conclusion": r"(?im)^\s*(?:\*\*?)?(?:conclusion|holding|verdict)(?:\*\*?)?\s*:?\s*\n?(.*?)(?=(?:\n\s*(?:\*\*?)?(?:issue|question presented|legal problem|rule|law|statute|legal principle|application|analysis|reasoning|applying the law)(?:\*\*?)?\s*:)|$)",
     }
 
     _MIN_KEYWORD_LEN = 4
     _MIN_RULE_WORDS_FOR_OVERLAP = 4
 
     def __init__(self) -> None:
-        self._compiled = {
-            k: re.compile(v) for k, v in self._SECTION_PATTERNS.items()
+        self._compiled = {k: re.compile(v, re.DOTALL) for k, v in self._SECTION_PATTERNS.items()}
+
+    def verify_structure(self, text: str) -> dict:
+        result = self.verify(text)
+        return {
+            "verified": result.verified,
+            "status": result.status,
+            "components": result.components,
+            "missing": result.missing_sections,
+            "error": result.message,
+            "coherence_issues": result.coherence_issues,
+            "structure_valid": result.structure_valid,
         }
 
-    def verify_structure(self, text: str) -> IRACResult:
+    def verify(self, text: str) -> IRACResult:
         """
         Check whether text contains all four IRAC sections and passes
         basic structural coherence checks.
@@ -178,9 +188,7 @@ class IRACGuard:
             ),
         )
 
-    def _extract_sections(
-        self, text: str
-    ) -> Tuple[Dict[str, str], List[str]]:
+    def _extract_sections(self, text: str) -> Tuple[Dict[str, str], List[str]]:
         """Extract IRAC section content. Returns (components, missing_sections)."""
         components: Dict[str, str] = {}
         missing: List[str] = []
@@ -208,17 +216,18 @@ class IRACGuard:
 
         for section, content in components.items():
             if not content:
-                issues.append(
-                    f"'{section}' section heading found but has no content."
-                )
+                issues.append(f"'{section}' section heading found but has no content.")
 
         rule_text = components.get("rule", "")
         app_text = components.get("application", "").lower()
         rule_words = rule_text.lower().split()
         rule_keywords = [w for w in rule_words if len(w) >= self._MIN_KEYWORD_LEN]
 
-        if len(rule_words) >= self._MIN_RULE_WORDS_FOR_OVERLAP:
-            overlap = [w for w in rule_keywords if w in app_text]
+        if len(rule_keywords) >= self._MIN_RULE_WORDS_FOR_OVERLAP:
+            import re as _re
+
+            app_words = set(_re.findall(r"\b\w+\b", app_text))
+            overlap = [w for w in rule_keywords if w in app_words]
             if not overlap:
                 issues.append(
                     "Application section shares no meaningful keywords with "

--- a/tests/test_irac_guard.py
+++ b/tests/test_irac_guard.py
@@ -1,0 +1,61 @@
+"""Tests for IRACGuard fail-closed semantics and verification boundaries."""
+
+from qwed_legal.guards.irac_guard import (
+    IRACGuard,
+    STATUS_COHERENCE_INVALID,
+    STATUS_STRUCTURE_INVALID,
+    STATUS_UNVERIFIABLE_REASONING,
+)
+
+
+def test_irac_nonsensical_analysis_fails_closed_or_unverifiable_but_never_verified():
+    """Issue #12: nonsense must never be represented as legally verified reasoning."""
+    guard = IRACGuard()
+    analysis = """
+    Issue: Is the sky blue?
+    Rule: The sky is always green.
+    Application: Applying the green-sky rule, the defendant is liable.
+    Conclusion: The defendant is liable.
+    """
+
+    result = guard.verify_structure(analysis)
+
+    assert result.status in {STATUS_COHERENCE_INVALID, STATUS_UNVERIFIABLE_REASONING}
+    assert result.verified is False
+    assert (
+        "REASONING UNVERIFIABLE" in result.message
+        or "COHERENCE INVALID" in result.message
+    )
+
+
+def test_irac_missing_section_is_structure_invalid():
+    """Missing IRAC sections should fail closed as structure invalid."""
+    guard = IRACGuard()
+    analysis = """
+    Issue: Was there a breach?
+    Rule: Breach requires duty and violation.
+    Conclusion: There was a breach.
+    """
+
+    result = guard.verify_structure(analysis)
+
+    assert result.structure_valid is False
+    assert result.status == STATUS_STRUCTURE_INVALID
+    assert "application" in result.missing_sections
+
+
+def test_irac_rule_application_disconnect_is_coherence_invalid():
+    """Rule/application disconnect should fail closed as coherence invalid."""
+    guard = IRACGuard()
+    analysis = """
+    Issue: Was payment due?
+    Rule: Contract payment obligation requires invoice acceptance before maturity date.
+    Application: The witness discussed weather conditions and traffic delays only.
+    Conclusion: Payment was due.
+    """
+
+    result = guard.verify_structure(analysis)
+
+    assert result.structure_valid is False
+    assert result.status == STATUS_COHERENCE_INVALID
+    assert any("shares no meaningful keywords" in issue for issue in result.coherence_issues)

--- a/tests/test_irac_guard.py
+++ b/tests/test_irac_guard.py
@@ -57,40 +57,41 @@ def test_irac_rule_application_disconnect_is_coherence_invalid():
     assert result.status == STATUS_COHERENCE_INVALID
     assert any("shares no meaningful keywords" in issue for issue in result.coherence_issues)
 
-    def test_irac_multiline_sections(self):
-        """CodeRabbit Major: Multiline sections should not be truncated."""
-        guard = IRACGuard()
-        analysis = """Issue: Is this multiline?
+
+def test_irac_multiline_sections():
+    """CodeRabbit Major: Multiline sections should not be truncated."""
+    guard = IRACGuard()
+    analysis = """Issue: Is this multiline?
 Yes it is.
 Rule: The rule says
 many things.
-Application: It applies
+Application: It applies the rule
 here.
 Conclusion: Therefore,
 yes."""
-        result = guard.verify(analysis)
-        assert result.structure_valid is True
-        assert "multiline" in result.components["issue"]
-        assert "many things" in result.components["rule"]
+    result = guard.verify(analysis)
+    assert result.structure_valid is True
+    assert "multiline" in result.components["issue"]
+    assert "many things" in result.components["rule"]
 
-    def test_irac_whole_word_overlap(self):
-        """CodeRabbit Major: Whole word overlap prevents false positives."""
-        guard = IRACGuard()
-        # "candidate" contains "date" but should not match
-        analysis = """
-        Issue: Was the date correct?
-        Rule: The date is critical.
-        Application: The candidate was hired.
-        Conclusion: Yes.
-        """
-        result = guard.verify(analysis)
-        assert result.status == STATUS_COHERENCE_INVALID
-
-    def test_verify_structure_backward_compat(self):
-        """Codex P2: verify_structure should return a dict."""
-        guard = IRACGuard()
-        analysis = "Issue: a\nRule: b\nApplication: c\nConclusion: d"
-        result = guard.verify_structure(analysis)
-        assert isinstance(result, dict)
-        assert result["verified"] is False
-        assert "status" in result
+def test_irac_whole_word_overlap():
+    """CodeRabbit Major: Whole word overlap prevents false positives."""
+    guard = IRACGuard()
+    # "candidate" contains "date" but should not match
+    analysis = """
+    Issue: Was the mandate correct?
+    Rule: The specific mandate is critical for the election process.
+    Application: The man was hired.
+    Conclusion: Yes.
+    """
+    result = guard.verify(analysis)
+    assert result.status == STATUS_COHERENCE_INVALID
+    
+def test_verify_structure_backward_compat():
+    """Codex P2: verify_structure should return a dict."""
+    guard = IRACGuard()
+    analysis = "Issue: a\nRule: b\nApplication: c\nConclusion: d"
+    result = guard.verify_structure(analysis)
+    assert isinstance(result, dict)
+    assert result["verified"] is False
+    assert "status" in result

--- a/tests/test_irac_guard.py
+++ b/tests/test_irac_guard.py
@@ -22,7 +22,10 @@ def test_irac_nonsensical_analysis_fails_closed_or_unverifiable_but_never_verifi
 
     assert result.status in {STATUS_COHERENCE_INVALID, STATUS_UNVERIFIABLE_REASONING}
     assert result.verified is False
-    assert "REASONING UNVERIFIABLE" in result.message or "COHERENCE INVALID" in result.message
+    assert (
+        "REASONING UNVERIFIABLE" in result.message
+        or "COHERENCE INVALID" in result.message
+    )
 
 
 def test_irac_missing_section_is_structure_invalid():
@@ -55,7 +58,9 @@ def test_irac_rule_application_disconnect_is_coherence_invalid():
 
     assert result.structure_valid is False
     assert result.status == STATUS_COHERENCE_INVALID
-    assert any("shares no meaningful keywords" in issue for issue in result.coherence_issues)
+    assert any(
+        "shares no meaningful keywords" in issue for issue in result.coherence_issues
+    )
 
 
 def test_irac_multiline_sections():
@@ -74,6 +79,7 @@ yes."""
     assert "multiline" in result.components["issue"]
     assert "many things" in result.components["rule"]
 
+
 def test_irac_whole_word_overlap():
     """CodeRabbit Major: Whole word overlap prevents false positives."""
     guard = IRACGuard()
@@ -86,7 +92,8 @@ def test_irac_whole_word_overlap():
     """
     result = guard.verify(analysis)
     assert result.status == STATUS_COHERENCE_INVALID
-    
+
+
 def test_verify_structure_backward_compat():
     """Codex P2: verify_structure should return a dict."""
     guard = IRACGuard()

--- a/tests/test_irac_guard.py
+++ b/tests/test_irac_guard.py
@@ -77,11 +77,11 @@ yes."""
 def test_irac_whole_word_overlap():
     """CodeRabbit Major: Whole word overlap prevents false positives."""
     guard = IRACGuard()
-    # "candidate" contains "date" but should not match
+    # Rule keyword "date" is a substring of Application word "candidate"\n    # but must NOT count as overlap under whole-word matching.
     analysis = """
-    Issue: Was the mandate correct?
-    Rule: The specific mandate is critical for the election process.
-    Application: The man was hired.
+    Issue: Was the candidate selected?
+    Rule: The selection date is critical for the hiring process.
+    Application: The candidate appeared confident during review.
     Conclusion: Yes.
     """
     result = guard.verify(analysis)

--- a/tests/test_irac_guard.py
+++ b/tests/test_irac_guard.py
@@ -18,14 +18,11 @@ def test_irac_nonsensical_analysis_fails_closed_or_unverifiable_but_never_verifi
     Conclusion: The defendant is liable.
     """
 
-    result = guard.verify_structure(analysis)
+    result = guard.verify(analysis)
 
     assert result.status in {STATUS_COHERENCE_INVALID, STATUS_UNVERIFIABLE_REASONING}
     assert result.verified is False
-    assert (
-        "REASONING UNVERIFIABLE" in result.message
-        or "COHERENCE INVALID" in result.message
-    )
+    assert "REASONING UNVERIFIABLE" in result.message or "COHERENCE INVALID" in result.message
 
 
 def test_irac_missing_section_is_structure_invalid():
@@ -37,7 +34,7 @@ def test_irac_missing_section_is_structure_invalid():
     Conclusion: There was a breach.
     """
 
-    result = guard.verify_structure(analysis)
+    result = guard.verify(analysis)
 
     assert result.structure_valid is False
     assert result.status == STATUS_STRUCTURE_INVALID
@@ -54,8 +51,46 @@ def test_irac_rule_application_disconnect_is_coherence_invalid():
     Conclusion: Payment was due.
     """
 
-    result = guard.verify_structure(analysis)
+    result = guard.verify(analysis)
 
     assert result.structure_valid is False
     assert result.status == STATUS_COHERENCE_INVALID
     assert any("shares no meaningful keywords" in issue for issue in result.coherence_issues)
+
+    def test_irac_multiline_sections(self):
+        """CodeRabbit Major: Multiline sections should not be truncated."""
+        guard = IRACGuard()
+        analysis = """Issue: Is this multiline?
+Yes it is.
+Rule: The rule says
+many things.
+Application: It applies
+here.
+Conclusion: Therefore,
+yes."""
+        result = guard.verify(analysis)
+        assert result.structure_valid is True
+        assert "multiline" in result.components["issue"]
+        assert "many things" in result.components["rule"]
+
+    def test_irac_whole_word_overlap(self):
+        """CodeRabbit Major: Whole word overlap prevents false positives."""
+        guard = IRACGuard()
+        # "candidate" contains "date" but should not match
+        analysis = """
+        Issue: Was the date correct?
+        Rule: The date is critical.
+        Application: The candidate was hired.
+        Conclusion: Yes.
+        """
+        result = guard.verify(analysis)
+        assert result.status == STATUS_COHERENCE_INVALID
+
+    def test_verify_structure_backward_compat(self):
+        """Codex P2: verify_structure should return a dict."""
+        guard = IRACGuard()
+        analysis = "Issue: a\nRule: b\nApplication: c\nConclusion: d"
+        result = guard.verify_structure(analysis)
+        assert isinstance(result, dict)
+        assert result["verified"] is False
+        assert "status" in result


### PR DESCRIPTION
### PR Description

This PR fixes **Issue #12** where `IRACGuard.verify_structure()` could be interpreted as validating legal reasoning instead of only IRAC structure/coherence.

#### Problem

`IRACGuard` is a structural/coherence guard, but format-compliant IRAC text could appear success-like and be misunderstood as verified legal reasoning.

#### What changed

- Added focused regression tests in `tests/test_irac_guard.py`:
  1. Nonsensical IRAC-formatted analysis is **never** treated as legally verified reasoning.
  2. Missing IRAC section returns `structure_invalid`.
  3. Rule/Application disconnect returns `coherence_invalid`.
- Covered explicit fail-closed behavior and status semantics:
  - `structure_invalid`
  - `coherence_invalid`
  - `unverifiable_reasoning`
- Ensured tests assert `result.verified is False` for non-proven reasoning paths.

#### Validation

```bash
python -m pytest tests/test_irac_guard.py -q
# 3 passed
```

#### Impact

- Preserves QWED fail-closed philosophy.
- Prevents structural compliance from being interpreted as legal proof.
- Adds durable regression coverage for verification-boundary behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced IRAC validation with clearer outcomes: detects missing sections, flags coherence issues, and reports when reasoning cannot be verified; verification now consistently reports "unverified" while providing structured feedback.

* **Tests**
  * Added comprehensive tests covering missing sections, coherence failures, multiline section handling, whole-word overlap edge cases, and backward-compatible verification output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QWED-AI/qwed-legal/pull/32?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->