### PR TITLE
feat(guards): verification_trace across all guards + fail-closed hardening (closes #21, #18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,42 @@ Some operate on partial rules or structured validation and should **not** be tre
 | `ContradictionGuard` | `PARTIAL / HEURISTIC` | Structured contradiction checks for a limited set of modeled clause categories |
 | `FairnessGuard` | `HEURISTIC / FAIL-CLOSED` | Counterfactual consistency signal only; never returns `verified=True` — fairness cannot be proven by text substitution (issue #18) |
 
+### Verification trace (auditability)
+
+Every guard returns a `verification_trace` — an ordered list of `VerificationStep`
+records that make each decision auditable. A trace is **not** a narrative
+explanation; each step carries an `evidence_type` that classifies *how* its
+output was derived:
+
+| `evidence_type` | Meaning | `is_proven()` |
+|-----------------|---------|---------------|
+| `DETERMINISTIC` | Proven by math/logic (Z3, date arithmetic, exact compare) | `True` |
+| `PARSED` | Read/matched from structure or lookup table — not authority proof | `False` |
+| `INFERRED` | Pattern/keyword derived — may be wrong on edge cases | `False` |
+| `HEURISTIC` | Approximate/statistical signal | `False` |
+| `UNSUPPORTED` | Guard cannot model this input — fail-closed | `False` |
+
+Only `DETERMINISTIC` steps constitute actual proof. `PARSED`, `INFERRED`,
+`HEURISTIC`, and `UNSUPPORTED` steps must **not** be treated as verification.
+
+```python
+from qwed_legal import StatuteOfLimitationsGuard, trace_to_dict
+
+result = StatuteOfLimitationsGuard().verify(
+    claim_type="breach_of_contract",
+    jurisdiction="California",
+    incident_date="2020-01-01",
+    filing_date="2023-01-01",
+)
+
+for step in result.verification_trace:
+    print(step.step, step.evidence_type, "->", step.output)
+
+# JSON-safe export for audit logs / external consumers
+serialized = trace_to_dict(result.verification_trace)
+# each entry includes an explicit "is_proven" flag
+```
+
 ### Example: citation format check
 
 ```python

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Some operate on partial rules or structured validation and should **not** be tre
 | `StatuteOfLimitationsGuard` | `PARTIAL / HEURISTIC` | Limitation-period calculations for supported jurisdictions and claim types |
 | `IRACGuard` | `PARTIAL / HEURISTIC` | IRAC structure and consistency checks, not proof of legal reasoning |
 | `ContradictionGuard` | `PARTIAL / HEURISTIC` | Structured contradiction checks for a limited set of modeled clause categories |
-| `FairnessGuard` | `PARTIAL / HEURISTIC` | Counterfactual consistency checks, not full fairness proof |
+| `FairnessGuard` | `HEURISTIC / FAIL-CLOSED` | Counterfactual consistency signal only; never returns `verified=True` — fairness cannot be proven by text substitution (issue #18) |
 
 ### Example: citation format check
 

--- a/qwed_legal/__init__.py
+++ b/qwed_legal/__init__.py
@@ -18,7 +18,7 @@ from qwed_legal.guards.irac_guard import IRACGuard
 from qwed_legal.guards.fairness_guard import FairnessGuard
 from qwed_legal.guards.contradiction_guard import ContradictionGuard, Clause
 from qwed_legal.guards.provenance_guard import ProvenanceGuard, ProvenanceRecord
-from qwed_legal.models import VerificationStep
+from qwed_legal.models import VerificationStep, trace_to_dict
 from qwed_legal.rag.sac_processor import SACProcessor
 
 __version__ = "0.4.0"
@@ -36,6 +36,7 @@ __all__ = [
     "ProvenanceGuard",
     "ProvenanceRecord",
     "VerificationStep",
+    "trace_to_dict",
     "SACProcessor",
     "LegalGuard",
 ]

--- a/qwed_legal/__init__.py
+++ b/qwed_legal/__init__.py
@@ -18,6 +18,7 @@ from qwed_legal.guards.irac_guard import IRACGuard
 from qwed_legal.guards.fairness_guard import FairnessGuard
 from qwed_legal.guards.contradiction_guard import ContradictionGuard, Clause
 from qwed_legal.guards.provenance_guard import ProvenanceGuard, ProvenanceRecord
+from qwed_legal.models import VerificationStep
 from qwed_legal.rag.sac_processor import SACProcessor
 
 __version__ = "0.4.0"
@@ -34,6 +35,7 @@ __all__ = [
     "Clause",
     "ProvenanceGuard",
     "ProvenanceRecord",
+    "VerificationStep",
     "SACProcessor",
     "LegalGuard",
 ]
@@ -77,7 +79,9 @@ class LegalGuard:
         """Verify a deadline calculation."""
         return self.deadline.verify(signing_date, term, claimed_deadline)
 
-    def verify_liability_cap(self, contract_value: float, cap_percentage: float, claimed_cap: float):
+    def verify_liability_cap(
+        self, contract_value: float, cap_percentage: float, claimed_cap: float
+    ):
         """Verify a liability cap calculation."""
         return self.liability.verify_cap(contract_value, cap_percentage, claimed_cap)
 
@@ -110,7 +114,9 @@ class LegalGuard:
             contract_type=contract_type,
         )
 
-    def verify_statute_of_limitations(self, claim_type: str, jurisdiction: str, incident_date: str, filing_date: str):
+    def verify_statute_of_limitations(
+        self, claim_type: str, jurisdiction: str, incident_date: str, filing_date: str
+    ):
         """Verify if claim is within statute of limitations."""
         return self.statute.verify(claim_type, jurisdiction, incident_date, filing_date)
 
@@ -127,15 +133,20 @@ class LegalGuard:
         """
         return self.contradiction.verify_consistency(clauses)
 
-    def verify_fairness(self, original_prompt: str, original_decision: str, protected_attribute_swap: dict[str, str]):
+    def verify_fairness(
+        self,
+        original_prompt: str,
+        original_decision: str,
+        protected_attribute_swap: dict[str, str],
+    ):
         """Test for algorithmic bias using counterfactual testing.
 
         Requires ``llm_client`` to be provided at init time.
         """
-        return self.fairness.verify_decision_fairness(original_prompt, original_decision, protected_attribute_swap)
+        return self.fairness.verify_decision_fairness(
+            original_prompt, original_decision, protected_attribute_swap
+        )
 
     def verify_provenance(self, content: str, provenance: dict):
         """Verify AI-generated content provenance and disclosure compliance."""
         return self.provenance.verify_provenance(content, provenance)
-
-

--- a/qwed_legal/guards/citation_guard.py
+++ b/qwed_legal/guards/citation_guard.py
@@ -26,6 +26,14 @@ import re
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
+from qwed_legal.models import (
+    VerificationStep,
+    STEP_RULE_IDENTIFIED,
+    STEP_CONCLUSION,
+    EVIDENCE_PARSED,
+    EVIDENCE_UNSUPPORTED,
+)
+
 
 # Status constants — use these instead of comparing strings directly
 #
@@ -76,6 +84,7 @@ class CitationResult:
     issues: List[str] = field(default_factory=list)
     message: str = ""
     risk: Optional[str] = None
+    verification_trace: list = field(default_factory=list)
 
     # ── Backward-compatibility properties ─────────────────────────────────────
     @property
@@ -238,6 +247,7 @@ class CitationGuard:
                     f"this case exists or is correctly identified. "
                     f"Format match is not proof of legal authority."
                 ),
+                verification_trace=self._format_match_trace(citation_type, text),
             )
 
         # Statute check (done after case patterns to avoid dual-matching)
@@ -262,6 +272,7 @@ class CitationGuard:
                     "FORMAT INVALID: Citation is missing a case name "
                     "(expected 'Party v. Party, ...' format for this reporter)."
                 ),
+                verification_trace=self._format_invalid_trace(text, "Missing case name"),
             )
 
         # Unknown/invalid reporter pattern
@@ -276,6 +287,7 @@ class CitationGuard:
                     "abbreviation. Supported reporters: "
                     f"{', '.join(self.CASE_PATTERNS.keys())}."
                 ),
+                verification_trace=self._format_invalid_trace(text, "Unknown reporter"),
             )
 
         return CitationResult(
@@ -284,6 +296,7 @@ class CitationGuard:
             citation=text,
             issues=["No valid citation found"],
             message="FORMAT INVALID: No recognizable citation pattern found in the text.",
+            verification_trace=self._format_invalid_trace(text, "No valid citation found"),
         )
 
     def verify_citation_format(self, text: str) -> Dict[str, Any]:
@@ -338,6 +351,7 @@ class CitationGuard:
                         f"AUTHORITY UNVERIFIABLE: CitationGuard cannot confirm "
                         f"this statute section exists or applies as cited."
                     ),
+                    verification_trace=self._format_match_trace(citation_type, text),
                 )
 
         return CitationResult(
@@ -349,6 +363,7 @@ class CitationGuard:
                 "FORMAT INVALID: No recognized statute citation pattern found. "
                 f"Supported patterns: {', '.join(self.STATUTE_PATTERNS.keys())}."
             ),
+            verification_trace=self._format_invalid_trace(text, "Invalid statute format"),
         )
 
     def verify_batch(self, citations: List[str]) -> BatchCitationResult:
@@ -367,6 +382,49 @@ class CitationGuard:
         )
 
     # ── Private helpers ────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _format_match_trace(citation_type: str, text: str) -> list:
+        """Trace for a format-matching citation. Format match is PARSED, not authority proof."""
+        return [
+            VerificationStep(
+                step=STEP_RULE_IDENTIFIED,
+                description="Matched citation string against a known reporter pattern.",
+                inputs={"citation": text, "citation_type": citation_type},
+                output=f"Format matched reporter pattern: {citation_type}",
+                evidence_type=EVIDENCE_PARSED,
+            ),
+            VerificationStep(
+                step=STEP_CONCLUSION,
+                description="Format is valid, but legal authority cannot be confirmed.",
+                inputs={"authority_database_access": False},
+                output=(
+                    "AUTHORITY UNVERIFIABLE: format match is not proof the cited "
+                    "authority exists."
+                ),
+                evidence_type=EVIDENCE_UNSUPPORTED,
+            ),
+        ]
+
+    @staticmethod
+    def _format_invalid_trace(text: str, issue: str) -> list:
+        """Trace for a citation that does not match any known format."""
+        return [
+            VerificationStep(
+                step=STEP_RULE_IDENTIFIED,
+                description="Checked citation string against known reporter patterns.",
+                inputs={"citation": text},
+                output=f"No matching pattern: {issue}",
+                evidence_type=EVIDENCE_PARSED,
+            ),
+            VerificationStep(
+                step=STEP_CONCLUSION,
+                description="Citation format is invalid.",
+                inputs={"issue": issue},
+                output="FORMAT INVALID",
+                evidence_type=EVIDENCE_UNSUPPORTED,
+            ),
+        ]
 
     @staticmethod
     def _parse_components(groupdict: Dict[str, Any]) -> Dict[str, Any]:

--- a/qwed_legal/guards/clause_guard.py
+++ b/qwed_legal/guards/clause_guard.py
@@ -5,11 +5,21 @@ Supports optional typed Z3 constraints for power users who model legal meaning
 explicitly outside this guard.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import re
 from typing import Any, List, Optional, Tuple
 
 from z3 import BoolRef, Solver, sat, unknown, unsat
+
+from qwed_legal.models import (
+    VerificationStep,
+    STEP_RULE_IDENTIFIED,
+    STEP_AMBIGUITY_NOTED,
+    STEP_CONCLUSION,
+    EVIDENCE_DETERMINISTIC,
+    EVIDENCE_INFERRED,
+    EVIDENCE_UNSUPPORTED,
+)
 
 
 @dataclass
@@ -25,6 +35,7 @@ class ClauseResult:
     #   "contradiction"               — at least one conflict detected
     #   "heuristic_pass_limited"      — no propositions extracted; guard has no coverage
     #                                   consistent=False but NOT a detected contradiction
+    verification_trace: list = field(default_factory=list)
 
 
 class ClauseGuard:
@@ -63,6 +74,15 @@ class ClauseGuard:
                 consistent=True,
                 conflicts=[],
                 message="Single clause - no conflicts possible.",
+                verification_trace=[
+                    VerificationStep(
+                        step=STEP_CONCLUSION,
+                        description="Fewer than two clauses provided — no pair to compare.",
+                        inputs={"clause_count": len(clauses)},
+                        output="NO CONFLICT POSSIBLE (single clause)",
+                        evidence_type=EVIDENCE_INFERRED,
+                    )
+                ],
             )
 
         # Extract logical propositions from clauses
@@ -84,6 +104,16 @@ class ClauseGuard:
         )
         ambiguous = [p for p in propositions if p["ambiguous_termination_reference"]]
         has_ambiguous = len(ambiguous) > 0
+
+        rule_step = VerificationStep(
+            step=STEP_RULE_IDENTIFIED,
+            description="Extracted heuristic propositions from clause text.",
+            inputs={"clause_count": len(clauses), "covered_propositions": covered},
+            output=(
+                "Heuristic patterns: termination, notice period, min-term, exclusivity."
+            ),
+            evidence_type=EVIDENCE_INFERRED,
+        )
 
         if not conflicts:
             if covered == 0 or has_ambiguous:
@@ -108,6 +138,16 @@ class ClauseGuard:
                         "confirm it — downstream consumers must not treat this as "
                         "verified consistency."
                     ),
+                    verification_trace=[
+                        rule_step,
+                        VerificationStep(
+                            step=STEP_AMBIGUITY_NOTED,
+                            description="Coverage is limited or ambiguous — cannot confirm consistency.",
+                            inputs={"covered": covered, "has_ambiguous": has_ambiguous},
+                            output="UNSUPPORTED: limited heuristic coverage, not verified.",
+                            evidence_type=EVIDENCE_UNSUPPORTED,
+                        ),
+                    ],
                 )
             return ClauseResult(
                 consistent=True,
@@ -118,6 +158,16 @@ class ClauseGuard:
                     "min-term, exclusivity) found no conflicts. This is a heuristic "
                     "result — not deterministic legal verification."
                 ),
+                verification_trace=[
+                    rule_step,
+                    VerificationStep(
+                        step=STEP_CONCLUSION,
+                        description="No conflicts found by supported heuristic checks.",
+                        inputs={"conflict_count": 0},
+                        output="NO CONFLICT DETECTED (heuristic, not proof)",
+                        evidence_type=EVIDENCE_INFERRED,
+                    ),
+                ],
             )
 
         conflict_msgs = []
@@ -134,6 +184,16 @@ class ClauseGuard:
                 f"WARNING: {len(conflicts)} potential conflict(s) detected:\n"
                 + "\n".join(conflict_msgs)
             ),
+            verification_trace=[
+                rule_step,
+                VerificationStep(
+                    step=STEP_CONCLUSION,
+                    description="Heuristic checks detected potential conflict(s).",
+                    inputs={"conflict_count": len(conflicts)},
+                    output=f"POTENTIAL CONFLICT(S): {len(conflicts)} (heuristic, not proof)",
+                    evidence_type=EVIDENCE_INFERRED,
+                ),
+            ],
         )
 
     def _extract_propositions(self, clauses: List[str]) -> List[dict]:
@@ -318,6 +378,15 @@ class ClauseGuard:
                     "UNVERIFIABLE: verify_using_z3 requires explicit Z3 "
                     "constraint expressions. Empty input cannot be proven."
                 ),
+                verification_trace=[
+                    VerificationStep(
+                        step=STEP_RULE_IDENTIFIED,
+                        description="No Z3 constraints provided.",
+                        inputs={"constraint_count": 0},
+                        output="UNSUPPORTED: empty constraint input.",
+                        evidence_type=EVIDENCE_UNSUPPORTED,
+                    )
+                ],
             )
 
         invalid_positions = [
@@ -335,6 +404,15 @@ class ClauseGuard:
                     "Boolean expressions. Unsupported constraint(s) at "
                     f"position(s): {positions}."
                 ),
+                verification_trace=[
+                    VerificationStep(
+                        step=STEP_RULE_IDENTIFIED,
+                        description="One or more inputs are not Z3 Boolean expressions.",
+                        inputs={"invalid_positions": invalid_positions},
+                        output="UNSUPPORTED: non-Boolean constraint input.",
+                        evidence_type=EVIDENCE_UNSUPPORTED,
+                    )
+                ],
             )
 
         solver = Solver()
@@ -346,6 +424,15 @@ class ClauseGuard:
                 consistent=True,
                 conflicts=[],
                 message="VERIFIED: Provided Z3 constraints are satisfiable.",
+                verification_trace=[
+                    VerificationStep(
+                        step=STEP_CONCLUSION,
+                        description="Z3 evaluated explicit constraints as satisfiable.",
+                        inputs={"z3_result": "sat", "constraint_count": len(constraints)},
+                        output="SATISFIABLE: no contradiction among provided constraints.",
+                        evidence_type=EVIDENCE_DETERMINISTIC,
+                    )
+                ],
             )
 
         if result == unsat:
@@ -356,6 +443,15 @@ class ClauseGuard:
                     "CONTRADICTION: Provided Z3 constraints are "
                     "unsatisfiable (contradiction exists)."
                 ),
+                verification_trace=[
+                    VerificationStep(
+                        step=STEP_CONCLUSION,
+                        description="Z3 evaluated explicit constraints as unsatisfiable.",
+                        inputs={"z3_result": "unsat", "constraint_count": len(constraints)},
+                        output="CONTRADICTION: no assignment satisfies all constraints.",
+                        evidence_type=EVIDENCE_DETERMINISTIC,
+                    )
+                ],
             )
 
         if result == unknown:
@@ -363,10 +459,28 @@ class ClauseGuard:
                 consistent=False,
                 conflicts=[],
                 message="UNVERIFIABLE: Z3 returned unknown for the provided constraints.",
+                verification_trace=[
+                    VerificationStep(
+                        step=STEP_CONCLUSION,
+                        description="Z3 returned unknown — cannot determine satisfiability.",
+                        inputs={"z3_result": "unknown"},
+                        output="UNSUPPORTED: Z3 could not determine satisfiability.",
+                        evidence_type=EVIDENCE_UNSUPPORTED,
+                    )
+                ],
             )
 
         return ClauseResult(
             consistent=False,
             conflicts=[],
             message="UNVERIFIABLE: Z3 returned an unsupported satisfiability state.",
+            verification_trace=[
+                VerificationStep(
+                    step=STEP_CONCLUSION,
+                    description="Z3 returned an unsupported satisfiability state.",
+                    inputs={"z3_result": str(result)},
+                    output="UNSUPPORTED: unexpected Z3 state.",
+                    evidence_type=EVIDENCE_UNSUPPORTED,
+                )
+            ],
         )

--- a/qwed_legal/guards/contradiction_guard.py
+++ b/qwed_legal/guards/contradiction_guard.py
@@ -14,6 +14,17 @@ from typing import List
 
 from z3 import Int, Solver, sat, unknown
 
+from qwed_legal.models import (
+    VerificationStep,
+    STEP_RULE_IDENTIFIED,
+    STEP_FACT_DERIVED,
+    STEP_AMBIGUITY_NOTED,
+    STEP_CONCLUSION,
+    EVIDENCE_DETERMINISTIC,
+    EVIDENCE_PARSED,
+    EVIDENCE_UNSUPPORTED,
+)
+
 
 @dataclass
 class Clause:
@@ -60,6 +71,15 @@ class ContradictionGuard:
                     "An empty clause list cannot be proven consistent."
                 ),
                 unsupported=[],
+                trace=[
+                    VerificationStep(
+                        step=STEP_RULE_IDENTIFIED,
+                        description="No clauses provided to verify.",
+                        inputs={"clauses": []},
+                        output="UNSUPPORTED: empty input cannot be proven consistent.",
+                        evidence_type=EVIDENCE_UNSUPPORTED,
+                    )
+                ],
             )
 
         supported, unsupported = self._partition_clauses(clauses)
@@ -75,6 +95,15 @@ class ContradictionGuard:
                     f"Cannot prove consistency for inputs that are not modeled."
                 ),
                 unsupported=unsupported_categories,
+                trace=[
+                    VerificationStep(
+                        step=STEP_RULE_IDENTIFIED,
+                        description="Clause categories partitioned: none are supported by this guard.",
+                        inputs={"categories_received": unsupported_categories},
+                        output=f"UNSUPPORTED: all categories unmodeled — {', '.join(unsupported_categories)}.",
+                        evidence_type=EVIDENCE_UNSUPPORTED,
+                    )
+                ],
             )
 
         s = Solver()
@@ -97,11 +126,62 @@ class ContradictionGuard:
                 s, clause, max_liability_usd
             )
 
+        # Build trace steps
+        trace = []
+        # Step 1: Rule identified
+        supported_cats = sorted({c.category for c in supported})
+        trace.append(
+            VerificationStep(
+                step=STEP_RULE_IDENTIFIED,
+                description="Partitioned clauses into supported and unsupported categories.",
+                inputs={"categories_all": sorted({c.category for c in clauses})},
+                output=(
+                    f"Supported: {', '.join(supported_cats)}"
+                    + (
+                        f". Unsupported: {', '.join(unsupported_categories)}"
+                        if unsupported_categories
+                        else ""
+                    )
+                ),
+                evidence_type=EVIDENCE_PARSED,
+            )
+        )
+        # Step 2: Fact derived per supported clause
+        for c in supported:
+            trace.append(
+                VerificationStep(
+                    step=STEP_FACT_DERIVED,
+                    description=f"Encoded Z3 constraint for {c.category} clause.",
+                    inputs={
+                        "clause_text": c.text,
+                        "clause_category": c.category,
+                        "clause_value": c.value,
+                    },
+                    output=f"Z3 constraint added for '{c.text}' (value={c.value})",
+                    evidence_type=EVIDENCE_DETERMINISTIC,
+                )
+            )
+        # Step 3: Ambiguity noted if partial coverage
+        if unsupported_categories or unmodeled_supported > 0:
+            trace.append(
+                VerificationStep(
+                    step=STEP_AMBIGUITY_NOTED,
+                    description="Partial coverage detected — not all clauses could be modeled.",
+                    inputs={
+                        "unsupported_categories": unsupported_categories,
+                        "unmodeled_count": unmodeled_supported,
+                    },
+                    output="PARTIAL_COVERAGE: verification result reflects incomplete modeling.",
+                    evidence_type=EVIDENCE_UNSUPPORTED,
+                )
+            )
+
         return self._build_result(
             s=s,
             unsupported_categories=unsupported_categories,
             has_unsupported=bool(unsupported),
             unmodeled_supported=unmodeled_supported,
+            trace=trace,
         )
 
     # ── private helpers ────────────────────────────────────────────────────────
@@ -148,12 +228,15 @@ class ContradictionGuard:
         return 0
 
     @staticmethod
-    def _unverifiable_result(message: str, unsupported: list) -> dict:
+    def _unverifiable_result(
+        message: str, unsupported: list, trace: list = None
+    ) -> dict:
         return {
             "verified": False,
             "status": "unverifiable",
             "message": message,
             "unsupported": unsupported,
+            "verification_trace": trace or [],
         }
 
     @staticmethod
@@ -162,6 +245,7 @@ class ContradictionGuard:
         unsupported_categories: list,
         has_unsupported: bool,
         unmodeled_supported: int,
+        trace: list = None,
     ) -> dict:
         """Evaluate Z3 solver and build the final result dict."""
         has_partial_modeling = has_unsupported or (unmodeled_supported > 0)
@@ -194,6 +278,16 @@ class ContradictionGuard:
                     f".{coverage_note}"
                 ),
                 "unsupported": unsupported_categories,
+                "verification_trace": (trace or [])
+                + [
+                    VerificationStep(
+                        step=STEP_CONCLUSION,
+                        description="Z3 solver evaluated: clauses are satisfiable.",
+                        inputs={"z3_result": "sat"},
+                        output="CONSISTENT: Z3 confirms no contradictions among modeled clauses.",
+                        evidence_type=EVIDENCE_DETERMINISTIC,
+                    )
+                ],
             }
 
         if result == unknown:
@@ -206,6 +300,16 @@ class ContradictionGuard:
                     f"Cannot determine consistency.{coverage_note}"
                 ),
                 "unsupported": unsupported_categories,
+                "verification_trace": (trace or [])
+                + [
+                    VerificationStep(
+                        step=STEP_CONCLUSION,
+                        description="Z3 returned unknown — constraints too complex or timeout.",
+                        inputs={"z3_result": "unknown"},
+                        output="UNVERIFIABLE: Z3 could not determine satisfiability.",
+                        evidence_type=EVIDENCE_UNSUPPORTED,
+                    )
+                ],
             }
 
         # result == unsat → contradiction
@@ -218,4 +322,14 @@ class ContradictionGuard:
                 f"duration).{coverage_note}"
             ),
             "unsupported": unsupported_categories,
+            "verification_trace": (trace or [])
+            + [
+                VerificationStep(
+                    step=STEP_CONCLUSION,
+                    description="Z3 evaluated: clauses are mutually contradictory.",
+                    inputs={"z3_result": "unsat"},
+                    output="CONTRADICTION: no assignment satisfies all constraints.",
+                    evidence_type=EVIDENCE_DETERMINISTIC,
+                )
+            ],
         }

--- a/qwed_legal/guards/contradiction_guard.py
+++ b/qwed_legal/guards/contradiction_guard.py
@@ -135,6 +135,7 @@ class ContradictionGuard:
         trace = []
         # Step 1: Rule identified
         supported_cats = sorted({c.category for c in supported})
+        categories_text = " and ".join(supported_cats)
         trace.append(
             VerificationStep(
                 step=STEP_RULE_IDENTIFIED,
@@ -186,6 +187,7 @@ class ContradictionGuard:
             unsupported_categories=unsupported_categories,
             has_unsupported=bool(unsupported),
             unmodeled_supported=unmodeled_supported,
+            categories_text=categories_text,
             trace=trace,
         )
 
@@ -252,23 +254,20 @@ class ContradictionGuard:
             if not has_partial_modeling
             else "PARTIAL_COVERAGE: satisfiable among modeled clauses only."
         )
-        evidence = (
-            EVIDENCE_DETERMINISTIC if not has_partial_modeling else EVIDENCE_UNSUPPORTED
-        )
         return VerificationStep(
             step=STEP_CONCLUSION,
             description="Z3 solver evaluated: clauses are satisfiable.",
             inputs={"z3_result": "sat", "partial_coverage": has_partial_modeling},
             output=output,
-            evidence_type=evidence,
+            evidence_type=EVIDENCE_DETERMINISTIC,
         )
 
     @staticmethod
-    def _z3_message(verified: bool, coverage_note: str) -> str:
+    def _z3_message(verified: bool, coverage_note: str, categories_text: str) -> str:
         """Build human-readable SAT message aligned to coverage status."""
         return (
             f"{'✅ CONSISTENT' if verified else '⚠️  PARTIAL COVERAGE'} "
-            f"(modeled clauses): The DURATION and LIABILITY clauses "
+            f"(modeled clauses): The {categories_text} clauses "
             f"{'are logically satisfiable' if verified else 'were not fully verified because modeling is incomplete'}"
             f".{coverage_note}"
         )
@@ -279,6 +278,7 @@ class ContradictionGuard:
         unsupported_categories: list,
         has_unsupported: bool,
         unmodeled_supported: int,
+        categories_text: str,
         trace: list = None,
     ) -> dict:
         """Evaluate Z3 solver and build the final result dict."""
@@ -306,7 +306,9 @@ class ContradictionGuard:
             return {
                 "verified": verified,
                 "status": status,
-                "message": ContradictionGuard._z3_message(verified, coverage_note),
+                "message": ContradictionGuard._z3_message(
+                    verified, coverage_note, categories_text
+                ),
                 "unsupported": unsupported_categories,
                 "verification_trace": (trace or [])
                 + [ContradictionGuard._sat_trace_step(has_partial_modeling)],

--- a/qwed_legal/guards/contradiction_guard.py
+++ b/qwed_legal/guards/contradiction_guard.py
@@ -113,18 +113,23 @@ class ContradictionGuard:
         s.add(max_liability_usd >= 0)
 
         unmodeled_supported = 0
+        encoded_supported = []
 
         duration_clauses = [c for c in supported if c.category.upper() == "DURATION"]
         for clause in duration_clauses:
-            unmodeled_supported += self._add_duration_constraint(
-                s, clause, contract_duration_months
-            )
+            add_result = self._add_duration_constraint(s, clause, contract_duration_months)
+            if add_result == 0:
+                encoded_supported.append(clause)
+            else:
+                unmodeled_supported += 1
 
         liability_clauses = [c for c in supported if c.category.upper() == "LIABILITY"]
         for clause in liability_clauses:
-            unmodeled_supported += self._add_liability_constraint(
-                s, clause, max_liability_usd
-            )
+            add_result = self._add_liability_constraint(s, clause, max_liability_usd)
+            if add_result == 0:
+                encoded_supported.append(clause)
+            else:
+                unmodeled_supported += 1
 
         # Build trace steps
         trace = []
@@ -147,7 +152,7 @@ class ContradictionGuard:
             )
         )
         # Step 2: Fact derived per supported clause
-        for c in supported:
+        for c in encoded_supported:
             trace.append(
                 VerificationStep(
                     step=STEP_FACT_DERIVED,
@@ -283,8 +288,12 @@ class ContradictionGuard:
                     VerificationStep(
                         step=STEP_CONCLUSION,
                         description="Z3 solver evaluated: clauses are satisfiable.",
-                        inputs={"z3_result": "sat"},
-                        output="CONSISTENT: Z3 confirms no contradictions among modeled clauses.",
+                        inputs={"z3_result": "sat", "partial_coverage": has_partial_modeling},
+                        output=(
+                            "CONSISTENT: Z3 confirms no contradictions among modeled clauses."
+                            if not has_partial_modeling
+                            else "PARTIAL_COVERAGE: satisfiable among modeled clauses only."
+                        ),
                         evidence_type=EVIDENCE_DETERMINISTIC,
                     )
                 ],

--- a/qwed_legal/guards/contradiction_guard.py
+++ b/qwed_legal/guards/contradiction_guard.py
@@ -245,6 +245,35 @@ class ContradictionGuard:
         }
 
     @staticmethod
+    def _sat_trace_step(has_partial_modeling: bool) -> VerificationStep:
+        """Build conclusion trace step for a SAT solver outcome."""
+        output = (
+            "CONSISTENT: Z3 confirms no contradictions among modeled clauses."
+            if not has_partial_modeling
+            else "PARTIAL_COVERAGE: satisfiable among modeled clauses only."
+        )
+        evidence = (
+            EVIDENCE_DETERMINISTIC if not has_partial_modeling else EVIDENCE_UNSUPPORTED
+        )
+        return VerificationStep(
+            step=STEP_CONCLUSION,
+            description="Z3 solver evaluated: clauses are satisfiable.",
+            inputs={"z3_result": "sat", "partial_coverage": has_partial_modeling},
+            output=output,
+            evidence_type=evidence,
+        )
+
+    @staticmethod
+    def _z3_message(verified: bool, coverage_note: str) -> str:
+        """Build human-readable SAT message aligned to coverage status."""
+        return (
+            f"{'✅ CONSISTENT' if verified else '⚠️  PARTIAL COVERAGE'} "
+            f"(modeled clauses): The DURATION and LIABILITY clauses "
+            f"{'are logically satisfiable' if verified else 'passed, but modeling is incomplete'}"
+            f".{coverage_note}"
+        )
+
+    @staticmethod
     def _build_result(
         s: Solver,
         unsupported_categories: list,
@@ -255,14 +284,6 @@ class ContradictionGuard:
         """Evaluate Z3 solver and build the final result dict."""
         has_unmodeled_supported = unmodeled_supported > 0
         has_partial_modeling = has_unsupported or has_unmodeled_supported
-        sat_output = (
-            "CONSISTENT: Z3 confirms no contradictions among modeled clauses."
-            if not has_partial_modeling
-            else "PARTIAL_COVERAGE: satisfiable among modeled clauses only."
-        )
-        sat_evidence = (
-            EVIDENCE_DETERMINISTIC if not has_partial_modeling else EVIDENCE_UNSUPPORTED
-        )
 
         coverage_note = ""
         if has_unsupported:
@@ -285,23 +306,10 @@ class ContradictionGuard:
             return {
                 "verified": verified,
                 "status": status,
-                "message": (
-                    f"{'✅ CONSISTENT' if verified else '⚠️  PARTIAL COVERAGE'} "
-                    f"(modeled clauses): The DURATION and LIABILITY clauses "
-                    f"{'are logically satisfiable' if verified else 'passed, but modeling is incomplete'}"
-                    f".{coverage_note}"
-                ),
+                "message": ContradictionGuard._z3_message(verified, coverage_note),
                 "unsupported": unsupported_categories,
                 "verification_trace": (trace or [])
-                + [
-                    VerificationStep(
-                        step=STEP_CONCLUSION,
-                        description="Z3 solver evaluated: clauses are satisfiable.",
-                        inputs={"z3_result": "sat", "partial_coverage": has_partial_modeling},
-                        output=sat_output,
-                        evidence_type=sat_evidence,
-                    )
-                ],
+                + [ContradictionGuard._sat_trace_step(has_partial_modeling)],
             }
 
         if result == unknown:

--- a/qwed_legal/guards/contradiction_guard.py
+++ b/qwed_legal/guards/contradiction_guard.py
@@ -269,7 +269,7 @@ class ContradictionGuard:
         return (
             f"{'✅ CONSISTENT' if verified else '⚠️  PARTIAL COVERAGE'} "
             f"(modeled clauses): The DURATION and LIABILITY clauses "
-            f"{'are logically satisfiable' if verified else 'passed, but modeling is incomplete'}"
+            f"{'are logically satisfiable' if verified else 'were not fully verified because modeling is incomplete'}"
             f".{coverage_note}"
         )
 

--- a/qwed_legal/guards/contradiction_guard.py
+++ b/qwed_legal/guards/contradiction_guard.py
@@ -254,6 +254,14 @@ class ContradictionGuard:
     ) -> dict:
         """Evaluate Z3 solver and build the final result dict."""
         has_partial_modeling = has_unsupported or (unmodeled_supported > 0)
+        sat_output = (
+            "CONSISTENT: Z3 confirms no contradictions among modeled clauses."
+            if not has_partial_modeling
+            else "PARTIAL_COVERAGE: satisfiable among modeled clauses only."
+        )
+        sat_evidence = (
+            EVIDENCE_DETERMINISTIC if not has_partial_modeling else EVIDENCE_UNSUPPORTED
+        )
 
         coverage_note = ""
         if has_unsupported:
@@ -289,12 +297,8 @@ class ContradictionGuard:
                         step=STEP_CONCLUSION,
                         description="Z3 solver evaluated: clauses are satisfiable.",
                         inputs={"z3_result": "sat", "partial_coverage": has_partial_modeling},
-                        output=(
-                            "CONSISTENT: Z3 confirms no contradictions among modeled clauses."
-                            if not has_partial_modeling
-                            else "PARTIAL_COVERAGE: satisfiable among modeled clauses only."
-                        ),
-                        evidence_type=EVIDENCE_DETERMINISTIC,
+                        output=sat_output,
+                        evidence_type=sat_evidence,
                     )
                 ],
             }

--- a/qwed_legal/guards/contradiction_guard.py
+++ b/qwed_legal/guards/contradiction_guard.py
@@ -253,7 +253,8 @@ class ContradictionGuard:
         trace: list = None,
     ) -> dict:
         """Evaluate Z3 solver and build the final result dict."""
-        has_partial_modeling = has_unsupported or (unmodeled_supported > 0)
+        has_unmodeled_supported = unmodeled_supported > 0
+        has_partial_modeling = has_unsupported or has_unmodeled_supported
         sat_output = (
             "CONSISTENT: Z3 confirms no contradictions among modeled clauses."
             if not has_partial_modeling
@@ -269,7 +270,7 @@ class ContradictionGuard:
                 f" NOTE: clause(s) with unsupported categories "
                 f"({', '.join(unsupported_categories)}) were excluded from the Z3 model."
             )
-        if unmodeled_supported > 0:
+        if has_unmodeled_supported:
             coverage_note += (
                 f" NOTE: {unmodeled_supported} supported-category clause(s) had "
                 f"unrecognized keyword patterns and could not be encoded."

--- a/qwed_legal/guards/deadline_guard.py
+++ b/qwed_legal/guards/deadline_guard.py
@@ -64,10 +64,20 @@ class DeadlineGuard:
         """
         self.country = country
         self.state = state
+        # Track whether the requested holiday calendar was actually built.
+        # QWED principle: no silent degradation. If we fall back to a different
+        # calendar, business-day computations must not be presented as proven.
+        self.holiday_calendar_valid = True
+        self.holiday_fallback_reason = None
         try:
             self.holiday_calendar = holidays.country_holidays(country, subdiv=state)
-        except Exception:
+        except Exception as e:
             self.holiday_calendar = holidays.US()
+            self.holiday_calendar_valid = False
+            self.holiday_fallback_reason = (
+                f"Could not build holiday calendar for country={country!r}, "
+                f"state={state!r}: {e}. Fell back to US() calendar."
+            )
     
     def verify(
         self,
@@ -117,7 +127,7 @@ class DeadlineGuard:
             )
         
         # Parse term and calculate deadline
-        computed = self._calculate_deadline(signing, term)
+        computed, used_business_days = self._calculate_deadline(signing, term)
         
         # Fail-closed: if the term is ambiguous, do not verify
         if computed is None:
@@ -149,12 +159,28 @@ class DeadlineGuard:
                     )
                 ],
             )
-        
+
         # Check difference
         diff = abs((claimed - computed).days)
         verified = diff <= tolerance_days
-        
-        if verified:
+
+        # QWED: if business days were used but the requested holiday calendar
+        # could not be built, the computation may rest on the wrong calendar.
+        # Do not present such a result as deterministic proof — fail closed.
+        calendar_unreliable = used_business_days and not self.holiday_calendar_valid
+        compute_evidence = (
+            EVIDENCE_UNSUPPORTED if calendar_unreliable else EVIDENCE_DETERMINISTIC
+        )
+
+        if calendar_unreliable:
+            verified = False
+            message = (
+                "⚠️ UNVERIFIABLE: This deadline uses business days, but the "
+                f"requested holiday calendar could not be built. "
+                f"{self.holiday_fallback_reason} Business-day results cannot be "
+                "proven against the wrong calendar."
+            )
+        elif verified:
             message = "✅ VERIFIED: Deadline calculation is correct."
         else:
             message = (
@@ -163,7 +189,13 @@ class DeadlineGuard:
                 f"but LLM claimed {claimed.strftime('%Y-%m-%d')}. "
                 f"Difference: {diff} days."
             )
-        
+
+        conclusion_output = (
+            "UNSUPPORTED: business-day calendar unavailable"
+            if calendar_unreliable
+            else ("DEADLINE VERIFIED" if verified else "DEADLINE MISMATCH")
+        )
+
         trace = [
             VerificationStep(
                 step=STEP_RULE_IDENTIFIED,
@@ -175,9 +207,14 @@ class DeadlineGuard:
             VerificationStep(
                 step=STEP_FACT_DERIVED,
                 description="Computed deadline from signing date and parsed term.",
-                inputs={"signing_date": str(signing), "term": term},
+                inputs={
+                    "signing_date": str(signing),
+                    "term": term,
+                    "used_business_days": used_business_days,
+                    "holiday_calendar_valid": self.holiday_calendar_valid,
+                },
                 output=f"Computed deadline: {computed.strftime('%Y-%m-%d')}",
-                evidence_type=EVIDENCE_DETERMINISTIC,
+                evidence_type=compute_evidence,
             ),
             VerificationStep(
                 step=STEP_FACT_DERIVED,
@@ -188,17 +225,21 @@ class DeadlineGuard:
                     "tolerance_days": tolerance_days,
                 },
                 output=f"Difference: {diff} day(s)",
-                evidence_type=EVIDENCE_DETERMINISTIC,
+                evidence_type=compute_evidence,
             ),
             VerificationStep(
                 step=STEP_CONCLUSION,
                 description="Determined whether the claimed deadline matches within tolerance.",
-                inputs={"difference_days": diff, "tolerance_days": tolerance_days},
-                output="DEADLINE VERIFIED" if verified else "DEADLINE MISMATCH",
-                evidence_type=EVIDENCE_DETERMINISTIC,
+                inputs={
+                    "difference_days": diff,
+                    "tolerance_days": tolerance_days,
+                    "calendar_unreliable": calendar_unreliable,
+                },
+                output=conclusion_output,
+                evidence_type=compute_evidence,
             ),
         ]
-        
+
         return DeadlineResult(
             verified=verified,
             signing_date=signing,
@@ -207,14 +248,19 @@ class DeadlineGuard:
             term_parsed=term,
             difference_days=diff,
             message=message,
+            is_computable=not calendar_unreliable,
             verification_trace=trace,
         )
     
-    def _calculate_deadline(self, start_date: datetime, term: str) -> Optional[datetime]:
+    def _calculate_deadline(
+        self, start_date: datetime, term: str
+    ) -> "tuple[Optional[datetime], bool]":
         """Calculate the actual deadline from a term description.
         
-        Returns None if the term is ambiguous and cannot be parsed into
-        a deterministic deadline (fail-closed).
+        Returns a tuple of (deadline, used_business_days). deadline is None if
+        the term is ambiguous and cannot be parsed into a deterministic
+        deadline (fail-closed); used_business_days indicates whether the
+        holiday calendar was relied upon.
         """
         term_lower = term.lower().strip()
         
@@ -222,7 +268,7 @@ class DeadlineGuard:
         numbers = re.findall(r'\d+', term_lower)
         if not numbers:
             # Fail-closed: no numeric quantity found — term is ambiguous
-            return None
+            return None, False
         
         num = int(numbers[0])
         
@@ -231,20 +277,20 @@ class DeadlineGuard:
         is_business_days = bool(re.search(r'\b(?:business|working|work)\b', term_lower))
         
         if re.search(r'\byears?\b', term_lower):
-            return start_date + relativedelta(years=num)
+            return start_date + relativedelta(years=num), False
         elif re.search(r'\bmonths?\b', term_lower):
-            return start_date + relativedelta(months=num)
+            return start_date + relativedelta(months=num), False
         elif re.search(r'\bweeks?\b', term_lower):
             if is_business_days:
-                return self._add_business_days(start_date, num * 5)
-            return start_date + timedelta(weeks=num)
+                return self._add_business_days(start_date, num * 5), True
+            return start_date + timedelta(weeks=num), False
         elif re.search(r'\b(?:days?|calendar\s+days?)\b', term_lower):
             if is_business_days:
-                return self._add_business_days(start_date, num)
-            return start_date + timedelta(days=num)
+                return self._add_business_days(start_date, num), True
+            return start_date + timedelta(days=num), False
         else:
             # Fail-closed: number found but no recognizable time unit
-            return None
+            return None, False
     
     def _add_business_days(self, start_date: datetime, days: int) -> datetime:
         """Add business days to a date, excluding weekends and holidays."""

--- a/qwed_legal/guards/deadline_guard.py
+++ b/qwed_legal/guards/deadline_guard.py
@@ -4,7 +4,7 @@ DeadlineGuard: Verify date calculations in legal contracts.
 Handles business days, calendar days, leap years, and holiday exclusions.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from typing import Optional
 import re
@@ -12,6 +12,16 @@ import re
 from dateutil.parser import parse as parse_date
 from dateutil.relativedelta import relativedelta
 import holidays
+
+from qwed_legal.models import (
+    VerificationStep,
+    STEP_RULE_IDENTIFIED,
+    STEP_FACT_DERIVED,
+    STEP_CONCLUSION,
+    EVIDENCE_DETERMINISTIC,
+    EVIDENCE_PARSED,
+    EVIDENCE_UNSUPPORTED,
+)
 
 
 @dataclass
@@ -26,6 +36,7 @@ class DeadlineResult:
     message: str
     is_computable: bool = True  # False if term is ambiguous/unparseable
     verification_mode: str = "SYMBOLIC"  # Always SYMBOLIC for legal (SymPy/Z3)
+    verification_trace: list = field(default_factory=list)
 
 
 class DeadlineGuard:
@@ -91,6 +102,18 @@ class DeadlineGuard:
                 difference_days=None,
                 message=f"Failed to parse dates: {e}",
                 is_computable=False,
+                verification_trace=[
+                    VerificationStep(
+                        step=STEP_RULE_IDENTIFIED,
+                        description="Date parsing failed — cannot proceed.",
+                        inputs={
+                            "signing_date": signing_date,
+                            "claimed_deadline": claimed_deadline,
+                        },
+                        output=f"UNSUPPORTED: parse error: {e}",
+                        evidence_type=EVIDENCE_UNSUPPORTED,
+                    )
+                ],
             )
         
         # Parse term and calculate deadline
@@ -113,6 +136,18 @@ class DeadlineGuard:
                     f"human legal interpretation."
                 ),
                 is_computable=False,
+                verification_trace=[
+                    VerificationStep(
+                        step=STEP_RULE_IDENTIFIED,
+                        description="Term parsed for a deterministic time quantity and unit.",
+                        inputs={"term": term},
+                        output=(
+                            "UNSUPPORTED: ambiguous term — no provable "
+                            "quantity/unit to compute a deadline."
+                        ),
+                        evidence_type=EVIDENCE_UNSUPPORTED,
+                    )
+                ],
             )
         
         # Check difference
@@ -129,6 +164,41 @@ class DeadlineGuard:
                 f"Difference: {diff} days."
             )
         
+        trace = [
+            VerificationStep(
+                step=STEP_RULE_IDENTIFIED,
+                description="Parsed term into a deterministic time quantity and unit.",
+                inputs={"term": term, "tolerance_days": tolerance_days},
+                output=f"Parsed term: '{term}'",
+                evidence_type=EVIDENCE_PARSED,
+            ),
+            VerificationStep(
+                step=STEP_FACT_DERIVED,
+                description="Computed deadline from signing date and parsed term.",
+                inputs={"signing_date": str(signing), "term": term},
+                output=f"Computed deadline: {computed.strftime('%Y-%m-%d')}",
+                evidence_type=EVIDENCE_DETERMINISTIC,
+            ),
+            VerificationStep(
+                step=STEP_FACT_DERIVED,
+                description="Computed difference between claimed and computed deadline.",
+                inputs={
+                    "claimed_deadline": str(claimed),
+                    "computed_deadline": str(computed),
+                    "tolerance_days": tolerance_days,
+                },
+                output=f"Difference: {diff} day(s)",
+                evidence_type=EVIDENCE_DETERMINISTIC,
+            ),
+            VerificationStep(
+                step=STEP_CONCLUSION,
+                description="Determined whether the claimed deadline matches within tolerance.",
+                inputs={"difference_days": diff, "tolerance_days": tolerance_days},
+                output="DEADLINE VERIFIED" if verified else "DEADLINE MISMATCH",
+                evidence_type=EVIDENCE_DETERMINISTIC,
+            ),
+        ]
+        
         return DeadlineResult(
             verified=verified,
             signing_date=signing,
@@ -136,7 +206,8 @@ class DeadlineGuard:
             computed_deadline=computed,
             term_parsed=term,
             difference_days=diff,
-            message=message
+            message=message,
+            verification_trace=trace,
         )
     
     def _calculate_deadline(self, start_date: datetime, term: str) -> Optional[datetime]:

--- a/qwed_legal/guards/deadline_guard.py
+++ b/qwed_legal/guards/deadline_guard.py
@@ -190,11 +190,12 @@ class DeadlineGuard:
                 f"Difference: {diff} days."
             )
 
-        conclusion_output = (
-            "UNSUPPORTED: business-day calendar unavailable"
-            if calendar_unreliable
-            else ("DEADLINE VERIFIED" if verified else "DEADLINE MISMATCH")
-        )
+        if calendar_unreliable:
+            conclusion_output = "UNSUPPORTED: business-day calendar unavailable"
+        elif verified:
+            conclusion_output = "DEADLINE VERIFIED"
+        else:
+            conclusion_output = "DEADLINE MISMATCH"
 
         trace = [
             VerificationStep(
@@ -248,7 +249,7 @@ class DeadlineGuard:
             term_parsed=term,
             difference_days=diff,
             message=message,
-            is_computable=not calendar_unreliable,
+            is_computable=True,
             verification_trace=trace,
         )
     

--- a/qwed_legal/guards/fairness_guard.py
+++ b/qwed_legal/guards/fairness_guard.py
@@ -1,29 +1,99 @@
+"""
+FairnessGuard: heuristic counterfactual fairness checks.
+
+IMPORTANT — scope of this guard (see issue #18):
+  FairnessGuard performs a single counterfactual swap and a deterministic
+  string comparison of decisions. This is a HEURISTIC signal, not a legal
+  fairness proof.
+
+  Fail-closed contract:
+  - This guard can NEVER return verified=True. Legal fairness cannot be proven
+    by text substitution + string equality.
+  - A consistent outcome is reported as UNVERIFIABLE_FAIRNESS (heuristic only):
+    it does not prove the absence of bias.
+  - A differing outcome is reported as a HEURISTIC bias *signal* that warrants
+    human review — not a deterministic proof of bias either, but it is a
+    fail-closed (verified=False) result.
+  - Incomplete fairness inputs (missing client, empty swap, None generation)
+    fail closed; they are never treated as safe.
+"""
+
 import re
 from typing import Dict, Any
 
+from qwed_legal.models import (
+    VerificationStep,
+    STEP_RULE_IDENTIFIED,
+    STEP_FACT_DERIVED,
+    STEP_CONCLUSION,
+    EVIDENCE_HEURISTIC,
+    EVIDENCE_UNSUPPORTED,
+)
+
+# Status constants
+STATUS_NO_SWAP_REQUIRED = "NO_SWAP_REQUIRED"
+STATUS_UNVERIFIABLE_FAIRNESS = "UNVERIFIABLE_FAIRNESS"
+STATUS_LLM_GENERATION_FAILED = "LLM_GENERATION_FAILED"
+
+# Risk constants
+RISK_HEURISTIC_BIAS_SIGNAL = "HEURISTIC_BIAS_SIGNAL"
+RISK_LLM_GENERATION_FAILED = "LLM_GENERATION_FAILED"
+
+
 class FairnessGuard:
     """
-    Evaluates algorithmic fairness using Counterfactual Testing.
-    Source: Inspired by the JudiFair benchmark for judicial fairness [Source 337, 338].
+    Evaluates algorithmic fairness using counterfactual testing.
+
+    This is a HEURISTIC guard. It can never prove fairness, so it never
+    returns verified=True. See issue #18.
     """
+
     def __init__(self, llm_client=None):
         self.llm_client = llm_client  # Used for synchronous counterfactual generation
 
-    def verify_decision_fairness(self, original_prompt: str, original_decision: str, protected_attribute_swap: Dict[str, str]) -> Dict[str, Any]:
+    def verify_decision_fairness(
+        self,
+        original_prompt: str,
+        original_decision: str,
+        protected_attribute_swap: Dict[str, str],
+    ) -> Dict[str, Any]:
         """
-        Swaps pronouns/names (e.g., "he" -> "she", "John" -> "Jane") and re-runs the prompt.
-        Deterministically compares the outcomes.
+        Swap protected attributes (e.g., "he" -> "she", "John" -> "Jane"),
+        re-run the prompt, and heuristically compare the outcomes.
+
+        Fail-closed: this method never returns verified=True. A consistent
+        outcome is UNVERIFIABLE_FAIRNESS (heuristic), not proof of fairness.
         """
         if not self.llm_client:
             raise ValueError("LLM client must be provided for counterfactual execution.")
 
         if not protected_attribute_swap:
-            return {"verified": True, "status": "NO_SWAP_REQUIRED", "message": "No protected attributes to swap."}
+            # No protected attributes to swap — fairness cannot be assessed.
+            # Fail-closed: this is not a verified-safe result.
+            return {
+                "verified": False,
+                "status": STATUS_UNVERIFIABLE_FAIRNESS,
+                "message": (
+                    "UNVERIFIABLE_FAIRNESS: No protected attributes provided to "
+                    "swap. Fairness cannot be assessed from incomplete input."
+                ),
+                "verification_trace": [
+                    VerificationStep(
+                        step=STEP_RULE_IDENTIFIED,
+                        description="No protected attributes supplied for counterfactual swap.",
+                        inputs={"protected_attribute_swap": protected_attribute_swap},
+                        output="UNSUPPORTED: incomplete fairness input.",
+                        evidence_type=EVIDENCE_UNSUPPORTED,
+                    )
+                ],
+            }
 
-        # 1. Generate Counterfactual Prompt (single-pass to avoid cascade re-substitution)
-        combined_pattern = r'\b(' + '|'.join(re.escape(k) for k in protected_attribute_swap) + r')\b'
+        # 1. Generate counterfactual prompt (single-pass to avoid cascade re-substitution)
+        combined_pattern = (
+            r"\b(" + "|".join(re.escape(k) for k in protected_attribute_swap) + r")\b"
+        )
         lower_swap_dict = {k.lower(): v for k, v in protected_attribute_swap.items()}
-        
+
         def match_case(match):
             word = match.group()
             rep = lower_swap_dict[word.lower()].lower()
@@ -32,28 +102,118 @@ class FairnessGuard:
             elif word.istitle():
                 return rep.capitalize()
             return rep
-            
-        counterfactual_prompt = re.sub(combined_pattern, match_case, original_prompt, flags=re.IGNORECASE)
 
-        # 2. Get Counterfactual Decision (sequential/synchronous)
+        counterfactual_prompt = re.sub(
+            combined_pattern, match_case, original_prompt, flags=re.IGNORECASE
+        )
+
+        # 2. Get counterfactual decision (sequential/synchronous)
         cf_decision = self.llm_client.generate(counterfactual_prompt)
-        
+
         if cf_decision is None:
             return {
                 "verified": False,
-                "risk": "LLM_GENERATION_FAILED",
-                "message": "The LLM client returned None for the counterfactual prompt."
+                "risk": RISK_LLM_GENERATION_FAILED,
+                "status": STATUS_LLM_GENERATION_FAILED,
+                "message": "The LLM client returned None for the counterfactual prompt.",
+                "verification_trace": [
+                    VerificationStep(
+                        step=STEP_RULE_IDENTIFIED,
+                        description="Generated counterfactual prompt via attribute swap.",
+                        inputs={"protected_attribute_swap": protected_attribute_swap},
+                        output="Counterfactual prompt generated.",
+                        evidence_type=EVIDENCE_HEURISTIC,
+                    ),
+                    VerificationStep(
+                        step=STEP_CONCLUSION,
+                        description="LLM returned no counterfactual decision.",
+                        inputs={"counterfactual_decision": None},
+                        output="UNSUPPORTED: counterfactual generation failed.",
+                        evidence_type=EVIDENCE_UNSUPPORTED,
+                    ),
+                ],
             }
 
-        # 3. Deterministic Equality Check (Strict outcome matching)
-        is_consistent = (original_decision.strip().lower() == cf_decision.strip().lower())
+        # 3. Heuristic equality check (strict outcome matching)
+        is_consistent = (
+            original_decision.strip().lower() == cf_decision.strip().lower()
+        )
+
+        trace = [
+            VerificationStep(
+                step=STEP_RULE_IDENTIFIED,
+                description="Generated counterfactual prompt via protected-attribute swap.",
+                inputs={"protected_attribute_swap": protected_attribute_swap},
+                output="Counterfactual prompt generated (heuristic substitution).",
+                evidence_type=EVIDENCE_HEURISTIC,
+            ),
+            VerificationStep(
+                step=STEP_FACT_DERIVED,
+                description="Compared original and counterfactual decisions by string equality.",
+                inputs={
+                    "original_decision": original_decision,
+                    "counterfactual_decision": cf_decision,
+                },
+                output=f"Outcomes {'match' if is_consistent else 'differ'} (string compare).",
+                evidence_type=EVIDENCE_HEURISTIC,
+            ),
+        ]
 
         if not is_consistent:
+            trace.append(
+                VerificationStep(
+                    step=STEP_CONCLUSION,
+                    description="Outcomes differed under counterfactual swap (heuristic signal).",
+                    inputs={
+                        "original": original_decision,
+                        "counterfactual": cf_decision,
+                    },
+                    output=(
+                        "HEURISTIC BIAS SIGNAL: outcome changed under swap — "
+                        "requires human review (not a deterministic proof)."
+                    ),
+                    evidence_type=EVIDENCE_HEURISTIC,
+                )
+            )
             return {
                 "verified": False,
-                "risk": "JUDICIAL_BIAS_DETECTED",
-                "message": "The agent's decision changed when protected attributes were altered. This violates fairness constraints.",
-                "variance": {"original": original_decision, "counterfactual": cf_decision}
+                "risk": RISK_HEURISTIC_BIAS_SIGNAL,
+                "status": STATUS_UNVERIFIABLE_FAIRNESS,
+                "message": (
+                    "HEURISTIC_BIAS_SIGNAL: The decision changed when protected "
+                    "attributes were altered. This is a heuristic signal that "
+                    "warrants human review; it is not a deterministic proof of "
+                    "bias, and fairness cannot be verified by this guard."
+                ),
+                "variance": {
+                    "original": original_decision,
+                    "counterfactual": cf_decision,
+                },
+                "verification_trace": trace,
             }
-            
-        return {"verified": True, "status": "FAIRNESS_VERIFIED"}
+
+        # Consistent outcome — fail-closed: NOT proof of fairness.
+        trace.append(
+            VerificationStep(
+                step=STEP_CONCLUSION,
+                description="Outcomes matched under a single counterfactual swap.",
+                inputs={"single_swap": True},
+                output=(
+                    "UNVERIFIABLE_FAIRNESS: consistent outcome under one swap is "
+                    "not proof of fairness."
+                ),
+                evidence_type=EVIDENCE_UNSUPPORTED,
+            )
+        )
+        return {
+            "verified": False,
+            "status": STATUS_UNVERIFIABLE_FAIRNESS,
+            "message": (
+                "UNVERIFIABLE_FAIRNESS: Outcomes were consistent under a single "
+                "counterfactual swap, but legal fairness cannot be proven by "
+                "heuristic text substitution and string equality. A single swap "
+                "does not prove fairness across relevant dimensions."
+            ),
+            "consistent": True,
+            "verification_trace": trace,
+        }

--- a/qwed_legal/guards/fairness_guard.py
+++ b/qwed_legal/guards/fairness_guard.py
@@ -88,6 +88,24 @@ class FairnessGuard:
                 ],
             }
 
+        # Fail-closed input validation: never silently process malformed swaps.
+        # 1) Keys and values must be non-null strings.
+        for key, value in protected_attribute_swap.items():
+            if not isinstance(key, str) or not isinstance(value, str):
+                raise ValueError(
+                    "protected_attribute_swap keys and values must be strings; "
+                    f"got key={key!r} ({type(key).__name__}), "
+                    f"value={value!r} ({type(value).__name__})."
+                )
+        # 2) Keys must not collide when lowercased (would silently lose a mapping).
+        lowered_keys = [k.lower() for k in protected_attribute_swap]
+        if len(set(lowered_keys)) != len(lowered_keys):
+            raise ValueError(
+                "protected_attribute_swap contains keys that collide when "
+                "lowercased (e.g., 'he' and 'He'). Case-insensitive matching "
+                "would silently drop a mapping; provide case-unique keys."
+            )
+
         # 1. Generate counterfactual prompt (single-pass to avoid cascade re-substitution)
         combined_pattern = (
             r"\b(" + "|".join(re.escape(k) for k in protected_attribute_swap) + r")\b"

--- a/qwed_legal/guards/irac_guard.py
+++ b/qwed_legal/guards/irac_guard.py
@@ -31,6 +31,15 @@ import re
 from dataclasses import dataclass, field
 from typing import Dict, List, Tuple
 
+from qwed_legal.models import (
+    VerificationStep,
+    STEP_RULE_IDENTIFIED,
+    STEP_AMBIGUITY_NOTED,
+    STEP_CONCLUSION,
+    EVIDENCE_INFERRED,
+    EVIDENCE_UNSUPPORTED,
+)
+
 # Status constants
 STATUS_STRUCTURE_INVALID = "structure_invalid"
 STATUS_COHERENCE_INVALID = "coherence_invalid"
@@ -63,6 +72,7 @@ class IRACResult:
     missing_sections: List[str] = field(default_factory=list)
     coherence_issues: List[str] = field(default_factory=list)
     message: str = ""
+    verification_trace: list = field(default_factory=list)
 
     @property
     def verified(self) -> bool:
@@ -158,6 +168,22 @@ class IRACGuard:
                     f"{', '.join(missing)}. Legal analysis must contain "
                     f"Issue, Rule, Application, and Conclusion."
                 ),
+                verification_trace=[
+                    VerificationStep(
+                        step=STEP_RULE_IDENTIFIED,
+                        description="Scanned text for the four IRAC sections.",
+                        inputs={"missing_sections": missing},
+                        output=f"Missing section(s): {', '.join(missing)}",
+                        evidence_type=EVIDENCE_INFERRED,
+                    ),
+                    VerificationStep(
+                        step=STEP_CONCLUSION,
+                        description="Required IRAC structure is incomplete.",
+                        inputs={"missing_count": len(missing)},
+                        output="STRUCTURE INVALID",
+                        evidence_type=EVIDENCE_UNSUPPORTED,
+                    ),
+                ],
             )
 
         coherence_issues = self._check_coherence(components)
@@ -174,6 +200,22 @@ class IRACGuard:
                     f"NOTE: Even coherent structure does not prove the "
                     f"reasoning is legally correct."
                 ),
+                verification_trace=[
+                    VerificationStep(
+                        step=STEP_RULE_IDENTIFIED,
+                        description="All four IRAC sections were located.",
+                        inputs={"sections": list(components.keys())},
+                        output="All IRAC sections present.",
+                        evidence_type=EVIDENCE_INFERRED,
+                    ),
+                    VerificationStep(
+                        step=STEP_AMBIGUITY_NOTED,
+                        description="Structural coherence checks failed.",
+                        inputs={"coherence_issues": coherence_issues},
+                        output="COHERENCE INVALID: structural signals inconsistent.",
+                        evidence_type=EVIDENCE_UNSUPPORTED,
+                    ),
+                ],
             )
 
         return IRACResult(
@@ -188,6 +230,25 @@ class IRACGuard:
                 "conclusion is legally correct. Structure check is not proof "
                 "of valid legal reasoning."
             ),
+            verification_trace=[
+                VerificationStep(
+                    step=STEP_RULE_IDENTIFIED,
+                    description="All four IRAC sections located and coherence checks passed.",
+                    inputs={"sections": list(components.keys())},
+                    output="Structure present and coherent (heuristic).",
+                    evidence_type=EVIDENCE_INFERRED,
+                ),
+                VerificationStep(
+                    step=STEP_CONCLUSION,
+                    description="Structure valid, but legal reasoning cannot be proven.",
+                    inputs={"reasoning_database_access": False},
+                    output=(
+                        "REASONING UNVERIFIABLE: structural validity is not proof "
+                        "of legally sound reasoning."
+                    ),
+                    evidence_type=EVIDENCE_UNSUPPORTED,
+                ),
+            ],
         )
 
     def _extract_sections(self, text: str) -> Tuple[Dict[str, str], List[str]]:

--- a/qwed_legal/guards/jurisdiction_guard.py
+++ b/qwed_legal/guards/jurisdiction_guard.py
@@ -320,6 +320,30 @@ class JurisdictionGuard:
         warnings = []
         selected_forum = forum if forum is not None else forum_selection
 
+        # Fail-closed: jurisdiction consistency cannot be verified without party
+        # information. An empty party list would otherwise produce no conflicts
+        # and falsely report verified=True.
+        if not parties_countries:
+            return JurisdictionResult(
+                verified=False,
+                conflicts=["No parties provided."],
+                governing_law=governing_law,
+                forum=selected_forum,
+                message=(
+                    "❌ UNVERIFIABLE: Cannot verify jurisdiction consistency "
+                    "without party country information."
+                ),
+                verification_trace=[
+                    VerificationStep(
+                        step=STEP_RULE_IDENTIFIED,
+                        description="No party countries provided to assess jurisdiction.",
+                        inputs={"parties_countries": parties_countries},
+                        output="UNSUPPORTED: empty party list cannot be verified.",
+                        evidence_type=EVIDENCE_UNSUPPORTED,
+                    )
+                ],
+            )
+
         # Normalize inputs (convert full state names to abbreviations)
         governing_law_upper = self._normalize_jurisdiction(governing_law)
         parties_upper = [self._normalize_party_country(p) for p in parties_countries]

--- a/qwed_legal/guards/jurisdiction_guard.py
+++ b/qwed_legal/guards/jurisdiction_guard.py
@@ -594,6 +594,27 @@ class JurisdictionGuard:
         convention_upper = convention.upper().replace(" ", "_")
         parties_upper = [p.upper().strip() for p in parties_countries]
 
+        # Fail-closed: with no parties, all([]) would be True and falsely report
+        # the convention as applicable. An empty party list cannot be verified.
+        if not parties_upper:
+            return JurisdictionResult(
+                verified=False,
+                conflicts=["No parties provided."],
+                message=(
+                    f"❌ UNVERIFIABLE: Cannot determine {convention} applicability "
+                    "with no parties specified."
+                ),
+                verification_trace=[
+                    VerificationStep(
+                        step=STEP_RULE_IDENTIFIED,
+                        description="No party countries provided to evaluate membership.",
+                        inputs={"parties": parties_upper, "convention": convention},
+                        output="UNSUPPORTED: empty party list cannot be verified.",
+                        evidence_type=EVIDENCE_UNSUPPORTED,
+                    )
+                ],
+            )
+
         if convention_upper not in self.INTERNATIONAL_CONVENTIONS:
             return JurisdictionResult(
                 verified=False,

--- a/qwed_legal/guards/jurisdiction_guard.py
+++ b/qwed_legal/guards/jurisdiction_guard.py
@@ -13,6 +13,7 @@ from qwed_legal.models import (
     STEP_RULE_IDENTIFIED,
     STEP_AMBIGUITY_NOTED,
     STEP_CONCLUSION,
+    EVIDENCE_DETERMINISTIC,
     EVIDENCE_PARSED,
     EVIDENCE_INFERRED,
     EVIDENCE_UNSUPPORTED,
@@ -538,12 +539,43 @@ class JurisdictionGuard:
             else f"❌ {conflicts[0]}"
         )
 
+        trace = [
+            VerificationStep(
+                step=STEP_RULE_IDENTIFIED,
+                description="Normalized forum and checked against known jurisdictions.",
+                inputs={"forum": forum, "contract_value": contract_value},
+                output=f"Normalized forum: {forum_upper}",
+                evidence_type=EVIDENCE_PARSED,
+            )
+        ]
+        if warnings:
+            trace.append(
+                VerificationStep(
+                    step=STEP_AMBIGUITY_NOTED,
+                    description="Heuristic threshold check produced warning(s).",
+                    inputs={"warnings": warnings},
+                    output="AMBIGUITY: warning(s) require human legal analysis.",
+                    evidence_type=EVIDENCE_UNSUPPORTED,
+                )
+            )
+        trace.append(
+            VerificationStep(
+                step=STEP_CONCLUSION,
+                description="Assessed forum validity via lookup membership.",
+                inputs={"conflict_count": len(conflicts)},
+                output="FORUM VALID" if verified else "FORUM NOT VERIFIED",
+                # Forum recognition is a parsed lookup, not formal legal proof.
+                evidence_type=EVIDENCE_INFERRED,
+            )
+        )
+
         return JurisdictionResult(
             verified=verified,
             conflicts=conflicts,
             warnings=warnings,
             forum=forum,
             message=message,
+            verification_trace=trace,
         )
 
     def check_convention_applicability(
@@ -567,17 +599,44 @@ class JurisdictionGuard:
                 verified=False,
                 conflicts=[f"Unknown convention: '{convention}'"],
                 message=f"❌ Unknown convention: '{convention}'",
+                verification_trace=[
+                    VerificationStep(
+                        step=STEP_RULE_IDENTIFIED,
+                        description="Looked up the requested convention in the known set.",
+                        inputs={"convention": convention},
+                        output=f"UNSUPPORTED: unknown convention '{convention}'.",
+                        evidence_type=EVIDENCE_UNSUPPORTED,
+                    )
+                ],
             )
 
         member_countries = self.INTERNATIONAL_CONVENTIONS[convention_upper]
         all_members = all(c in member_countries for c in parties_upper)
         some_members = any(c in member_countries for c in parties_upper)
 
+        rule_step = VerificationStep(
+            step=STEP_RULE_IDENTIFIED,
+            description="Matched parties against the convention's member states.",
+            inputs={"convention": convention_upper, "parties": parties_upper},
+            output=f"Member set resolved for {convention_upper}.",
+            evidence_type=EVIDENCE_PARSED,
+        )
+
         if all_members:
             return JurisdictionResult(
                 verified=True,
                 message=f"✅ {convention} applies - all parties are from member states.",
                 warnings=[],
+                verification_trace=[
+                    rule_step,
+                    VerificationStep(
+                        step=STEP_CONCLUSION,
+                        description="All parties are members of the convention (set membership).",
+                        inputs={"all_members": True},
+                        output=f"{convention_upper} APPLIES",
+                        evidence_type=EVIDENCE_DETERMINISTIC,
+                    ),
+                ],
             )
         elif some_members:
             non_members = [c for c in parties_upper if c not in member_countries]
@@ -585,12 +644,39 @@ class JurisdictionGuard:
                 verified=False,
                 warnings=[f"Not all parties are {convention} members: {non_members}"],
                 message=f"⚠️ {convention} may not apply to all parties.",
+                verification_trace=[
+                    rule_step,
+                    VerificationStep(
+                        step=STEP_AMBIGUITY_NOTED,
+                        description="Only some parties are convention members.",
+                        inputs={"non_members": non_members},
+                        output="AMBIGUITY: partial membership — applicability unclear.",
+                        evidence_type=EVIDENCE_UNSUPPORTED,
+                    ),
+                    VerificationStep(
+                        step=STEP_CONCLUSION,
+                        description="Convention may not apply to all parties.",
+                        inputs={"all_members": False, "some_members": True},
+                        output=f"{convention_upper} MAY NOT APPLY",
+                        evidence_type=EVIDENCE_DETERMINISTIC,
+                    ),
+                ],
             )
         else:
             return JurisdictionResult(
                 verified=False,
                 conflicts=[f"No parties are {convention} member states."],
                 message=f"❌ {convention} does not apply.",
+                verification_trace=[
+                    rule_step,
+                    VerificationStep(
+                        step=STEP_CONCLUSION,
+                        description="No parties are members of the convention (set membership).",
+                        inputs={"some_members": False},
+                        output=f"{convention_upper} DOES NOT APPLY",
+                        evidence_type=EVIDENCE_DETERMINISTIC,
+                    ),
+                ],
             )
 
     def _is_valid_jurisdiction(self, jurisdiction: str) -> bool:

--- a/qwed_legal/guards/jurisdiction_guard.py
+++ b/qwed_legal/guards/jurisdiction_guard.py
@@ -556,12 +556,19 @@ class JurisdictionGuard:
                     "jurisdiction threshold ($75,000) for US federal court."
                 )
 
-        verified = len(conflicts) == 0
-        message = (
-            "✅ VERIFIED: Forum selection is valid."
-            if verified
-            else f"❌ {conflicts[0]}"
-        )
+        # Fail-closed and consistent with verify_choice_of_law: warnings (e.g.
+        # an unresolved diversity-jurisdiction threshold) are ambiguities that
+        # must not pass verification.
+        verified = len(conflicts) == 0 and len(warnings) == 0
+        if conflicts:
+            message = f"❌ {conflicts[0]}"
+        elif warnings:
+            message = (
+                f"⚠️ AMBIGUOUS / UNVERIFIABLE: {len(warnings)} unresolved forum "
+                "warning(s) require legal analysis before verification."
+            )
+        else:
+            message = "✅ VERIFIED: Forum selection is valid."
 
         trace = [
             VerificationStep(
@@ -586,7 +593,10 @@ class JurisdictionGuard:
             VerificationStep(
                 step=STEP_CONCLUSION,
                 description="Assessed forum validity via lookup membership.",
-                inputs={"conflict_count": len(conflicts)},
+                inputs={
+                    "conflict_count": len(conflicts),
+                    "warning_count": len(warnings),
+                },
                 output="FORUM VALID" if verified else "FORUM NOT VERIFIED",
                 # Forum recognition is a parsed lookup, not formal legal proof.
                 evidence_type=EVIDENCE_INFERRED,

--- a/qwed_legal/guards/jurisdiction_guard.py
+++ b/qwed_legal/guards/jurisdiction_guard.py
@@ -8,6 +8,16 @@ from dataclasses import dataclass, field
 from typing import List, Optional, Dict, Set
 from enum import Enum
 
+from qwed_legal.models import (
+    VerificationStep,
+    STEP_RULE_IDENTIFIED,
+    STEP_AMBIGUITY_NOTED,
+    STEP_CONCLUSION,
+    EVIDENCE_PARSED,
+    EVIDENCE_INFERRED,
+    EVIDENCE_UNSUPPORTED,
+)
+
 
 class JurisdictionType(Enum):
     """Types of jurisdiction clauses."""
@@ -27,6 +37,7 @@ class JurisdictionResult:
     governing_law: Optional[str] = None
     forum: Optional[str] = None
     message: str = ""
+    verification_trace: list = field(default_factory=list)
 
 
 class JurisdictionGuard:
@@ -438,6 +449,46 @@ class JurisdictionGuard:
         else:
             message = f"❌ CONFLICTS DETECTED: {len(conflicts)} issue(s) found."
 
+        trace = [
+            VerificationStep(
+                step=STEP_RULE_IDENTIFIED,
+                description="Normalized and classified jurisdiction inputs from lookup tables.",
+                inputs={
+                    "governing_law": governing_law,
+                    "forum": selected_forum,
+                    "parties_countries": parties_countries,
+                },
+                output=(
+                    f"Governing law: {governing_law_upper}; "
+                    f"forum: {forum_upper}; parties: {parties_upper}"
+                ),
+                evidence_type=EVIDENCE_PARSED,
+            )
+        ]
+        if warnings:
+            trace.append(
+                VerificationStep(
+                    step=STEP_AMBIGUITY_NOTED,
+                    description="Heuristic cross-border/forum checks produced warnings.",
+                    inputs={"warnings": warnings},
+                    output="AMBIGUITY: warnings require human legal analysis.",
+                    evidence_type=EVIDENCE_UNSUPPORTED,
+                )
+            )
+        trace.append(
+            VerificationStep(
+                step=STEP_CONCLUSION,
+                description="Assessed jurisdiction consistency via lookup and heuristic checks.",
+                inputs={
+                    "conflict_count": len(conflicts),
+                    "warning_count": len(warnings),
+                },
+                output="CONSISTENT" if verified else "NOT VERIFIED",
+                # Conflict/warning detection is heuristic, not formal proof.
+                evidence_type=EVIDENCE_INFERRED,
+            )
+        )
+
         return JurisdictionResult(
             verified=verified,
             conflicts=conflicts,
@@ -445,6 +496,7 @@ class JurisdictionGuard:
             governing_law=governing_law,
             forum=selected_forum,
             message=message,
+            verification_trace=trace,
         )
 
     def verify_forum_selection(

--- a/qwed_legal/guards/liability_guard.py
+++ b/qwed_legal/guards/liability_guard.py
@@ -5,9 +5,16 @@ Catches percentage miscalculations, cap verification errors, and multi-tier liab
 """
 
 import warnings
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from decimal import Decimal, ROUND_HALF_UP
 from typing import List, Optional
+
+from qwed_legal.models import (
+    VerificationStep,
+    STEP_FACT_DERIVED,
+    STEP_CONCLUSION,
+    EVIDENCE_DETERMINISTIC,
+)
 
 
 @dataclass
@@ -20,6 +27,7 @@ class LiabilityResult:
     computed_cap: Decimal
     difference: Decimal
     message: str
+    verification_trace: list = field(default_factory=list)
 
 
 @dataclass
@@ -30,6 +38,7 @@ class TieredLiabilityResult:
     total_computed: Decimal
     claimed_total: Decimal
     message: str
+    verification_trace: list = field(default_factory=list)
 
 
 class LiabilityGuard:
@@ -115,7 +124,26 @@ class LiabilityGuard:
             claimed_cap=claimed,
             computed_cap=computed,
             difference=difference,
-            message=message
+            message=message,
+            verification_trace=[
+                VerificationStep(
+                    step=STEP_FACT_DERIVED,
+                    description="Computed liability cap as percentage of contract value.",
+                    inputs={
+                        "contract_value": str(cv),
+                        "cap_percentage": str(cap_percentage),
+                    },
+                    output=f"Computed cap: {computed}",
+                    evidence_type=EVIDENCE_DETERMINISTIC,
+                ),
+                VerificationStep(
+                    step=STEP_CONCLUSION,
+                    description="Compared claimed cap to computed cap (exact match required).",
+                    inputs={"claimed_cap": str(claimed), "computed_cap": str(computed)},
+                    output="CAP VERIFIED" if verified else "CAP MISMATCH",
+                    evidence_type=EVIDENCE_DETERMINISTIC,
+                ),
+            ],
         )
     
     def verify_tiered_liability(
@@ -168,7 +196,26 @@ class LiabilityGuard:
             tiers=computed_tiers,
             total_computed=total_computed,
             claimed_total=claimed,
-            message=message
+            message=message,
+            verification_trace=[
+                VerificationStep(
+                    step=STEP_FACT_DERIVED,
+                    description="Computed total liability across all tiers.",
+                    inputs={"tier_count": len(tiers)},
+                    output=f"Computed total: {total_computed}",
+                    evidence_type=EVIDENCE_DETERMINISTIC,
+                ),
+                VerificationStep(
+                    step=STEP_CONCLUSION,
+                    description="Compared claimed total to computed total (exact match required).",
+                    inputs={
+                        "claimed_total": str(claimed),
+                        "computed_total": str(total_computed),
+                    },
+                    output="TOTAL VERIFIED" if verified else "TOTAL MISMATCH",
+                    evidence_type=EVIDENCE_DETERMINISTIC,
+                ),
+            ],
         )
     
     def verify_indemnity_limit(
@@ -216,5 +263,21 @@ class LiabilityGuard:
             claimed_cap=claimed,
             computed_cap=computed,
             difference=difference,
-            message=message
+            message=message,
+            verification_trace=[
+                VerificationStep(
+                    step=STEP_FACT_DERIVED,
+                    description="Computed indemnity limit as multiplier of annual fee.",
+                    inputs={"annual_fee": str(fee), "multiplier": str(mult)},
+                    output=f"Computed limit: {computed}",
+                    evidence_type=EVIDENCE_DETERMINISTIC,
+                ),
+                VerificationStep(
+                    step=STEP_CONCLUSION,
+                    description="Compared claimed limit to computed limit (exact match required).",
+                    inputs={"claimed_limit": str(claimed), "computed_limit": str(computed)},
+                    output="LIMIT VERIFIED" if verified else "LIMIT MISMATCH",
+                    evidence_type=EVIDENCE_DETERMINISTIC,
+                ),
+            ],
         )

--- a/qwed_legal/guards/statute_guard.py
+++ b/qwed_legal/guards/statute_guard.py
@@ -435,18 +435,20 @@ class StatuteOfLimitationsGuard:
             claim_matches = claimed_within_period == within_period
             trace.append(
                 VerificationStep(
-                    step=STEP_FACT_DERIVED,
+                    step=STEP_CONCLUSION,
                     description="Compared claimed within-period answer to computed result.",
                     inputs={
                         "claimed_within_period": claimed_within_period,
                         "computed_within_period": within_period,
                     },
                     output=(
-                        "CLAIM_MATCH"
+                        "CLAIM VERIFIED"
                         if claim_matches
-                        else "CLAIM_MISMATCH"
+                        else "CLAIM INCORRECT"
                     ),
-                    evidence_type=EVIDENCE_DETERMINISTIC,
+                    evidence_type=(
+                        EVIDENCE_DETERMINISTIC if claim_matches else EVIDENCE_UNSUPPORTED
+                    ),
                 )
             )
         trace.append(

--- a/qwed_legal/guards/statute_guard.py
+++ b/qwed_legal/guards/statute_guard.py
@@ -446,23 +446,22 @@ class StatuteOfLimitationsGuard:
                         if claim_matches
                         else "CLAIM INCORRECT"
                     ),
-                    evidence_type=(
-                        EVIDENCE_DETERMINISTIC if claim_matches else EVIDENCE_UNSUPPORTED
-                    ),
+                    evidence_type=EVIDENCE_DETERMINISTIC,
                 )
             )
-        trace.append(
-            VerificationStep(
-                step=STEP_CONCLUSION,
-                description="Determined whether the claim falls within the statute of limitations.",
-                inputs={
-                    "within_period": within_period,
-                    "days_remaining": days_remaining,
-                },
-                output="WITHIN STATUTE" if within_period else "EXPIRED",
-                evidence_type=EVIDENCE_DETERMINISTIC,
+        else:
+            trace.append(
+                VerificationStep(
+                    step=STEP_CONCLUSION,
+                    description="Determined whether the claim falls within the statute of limitations.",
+                    inputs={
+                        "within_period": within_period,
+                        "days_remaining": days_remaining,
+                    },
+                    output="WITHIN STATUTE" if within_period else "EXPIRED",
+                    evidence_type=EVIDENCE_DETERMINISTIC,
+                )
             )
-        )
         return StatuteResult(
             verified=verified,
             claim_type=claim_type,

--- a/qwed_legal/guards/statute_guard.py
+++ b/qwed_legal/guards/statute_guard.py
@@ -430,6 +430,26 @@ class StatuteOfLimitationsGuard:
                 ),
                 evidence_type=EVIDENCE_DETERMINISTIC,
             ),
+        ]
+        if claimed_within_period is not None:
+            claim_matches = claimed_within_period == within_period
+            trace.append(
+                VerificationStep(
+                    step=STEP_FACT_DERIVED,
+                    description="Compared claimed within-period answer to computed result.",
+                    inputs={
+                        "claimed_within_period": claimed_within_period,
+                        "computed_within_period": within_period,
+                    },
+                    output=(
+                        "CLAIM_MATCH"
+                        if claim_matches
+                        else "CLAIM_MISMATCH"
+                    ),
+                    evidence_type=EVIDENCE_DETERMINISTIC,
+                )
+            )
+        trace.append(
             VerificationStep(
                 step=STEP_CONCLUSION,
                 description="Determined whether the claim falls within the statute of limitations.",
@@ -439,8 +459,8 @@ class StatuteOfLimitationsGuard:
                 },
                 output="WITHIN STATUTE" if within_period else "EXPIRED",
                 evidence_type=EVIDENCE_DETERMINISTIC,
-            ),
-        ]
+            )
+        )
         return StatuteResult(
             verified=verified,
             claim_type=claim_type,

--- a/qwed_legal/guards/statute_guard.py
+++ b/qwed_legal/guards/statute_guard.py
@@ -4,7 +4,7 @@ StatuteOfLimitationsGuard: Verify statute of limitations claims.
 Validates claim periods by jurisdiction and claim type.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Optional, Dict
 from enum import Enum
@@ -12,9 +12,20 @@ from enum import Enum
 from dateutil.parser import parse as parse_date
 from dateutil.relativedelta import relativedelta
 
+from qwed_legal.models import (
+    VerificationStep,
+    STEP_RULE_IDENTIFIED,
+    STEP_FACT_DERIVED,
+    STEP_CONCLUSION,
+    EVIDENCE_DETERMINISTIC,
+    EVIDENCE_PARSED,
+    EVIDENCE_UNSUPPORTED,
+)
+
 
 class ClaimType(Enum):
     """Types of legal claims with different limitation periods."""
+
     BREACH_OF_CONTRACT = "breach_of_contract"
     BREACH_OF_WARRANTY = "breach_of_warranty"
     NEGLIGENCE = "negligence"
@@ -30,6 +41,7 @@ class ClaimType(Enum):
 @dataclass
 class StatuteResult:
     """Result of statute of limitations verification."""
+
     verified: bool
     claim_type: str
     jurisdiction: str
@@ -40,18 +52,19 @@ class StatuteResult:
     days_remaining: Optional[int]
     message: str
     jurisdiction_matched: bool = True  # False if jurisdiction is unknown
-    claim_type_matched: bool = True    # False if claim type is unknown
+    claim_type_matched: bool = True  # False if claim type is unknown
+    verification_trace: list = field(default_factory=list)
 
 
 class StatuteOfLimitationsGuard:
     """
     Verify statute of limitations claims.
-    
+
     Catches common LLM errors like:
     - Incorrect limitation periods by jurisdiction
     - Missing tolling provisions
     - Discovery rule misapplication
-    
+
     Example:
         >>> guard = StatuteOfLimitationsGuard()
         >>> result = guard.verify(
@@ -62,7 +75,7 @@ class StatuteOfLimitationsGuard:
         ... )
         >>> print(result.verified)  # False - 4 year limit exceeded
     """
-    
+
     # Statute of limitations by jurisdiction and claim type (in years)
     # Source: General legal references - actual practice requires legal counsel
     LIMITATIONS: Dict[str, Dict[str, float]] = {
@@ -229,30 +242,29 @@ class StatuteOfLimitationsGuard:
             "defamation": 2.0,
         },
     }
-    
-    
+
     def __init__(self):
         """Initialize StatuteOfLimitationsGuard."""
         pass
-    
+
     def verify(
         self,
         claim_type: str,
         jurisdiction: str,
         incident_date: str,
         filing_date: str,
-        claimed_within_period: Optional[bool] = None
+        claimed_within_period: Optional[bool] = None,
     ) -> StatuteResult:
         """
         Verify if a claim is within the statute of limitations.
-        
+
         Args:
             claim_type: Type of claim (e.g., "breach_of_contract")
             jurisdiction: State or country name
             incident_date: Date the incident occurred
             filing_date: Date the claim was/will be filed
             claimed_within_period: Optional LLM claim to verify
-            
+
         Returns:
             StatuteResult with verification status
         """
@@ -273,12 +285,24 @@ class StatuteOfLimitationsGuard:
                 message=f"Failed to parse dates: {e}",
                 jurisdiction_matched=False,
                 claim_type_matched=False,
+                verification_trace=[
+                    VerificationStep(
+                        step=STEP_RULE_IDENTIFIED,
+                        description="Date parsing failed — cannot proceed.",
+                        inputs={
+                            "incident_date": incident_date,
+                            "filing_date": filing_date,
+                        },
+                        output=f"PARSE ERROR: {e}",
+                        evidence_type=EVIDENCE_UNSUPPORTED,
+                    )
+                ],
             )
-        
+
         # Get limitation period
         claim_type_lower = claim_type.lower().replace(" ", "_")
         jurisdiction_upper = jurisdiction.upper().strip()
-        
+
         # Fail-closed: exact jurisdiction match only (no partial matching)
         if jurisdiction_upper not in self.LIMITATIONS:
             return StatuteResult(
@@ -298,10 +322,19 @@ class StatuteOfLimitationsGuard:
                 ),
                 jurisdiction_matched=False,
                 claim_type_matched=False,
+                verification_trace=[
+                    VerificationStep(
+                        step=STEP_RULE_IDENTIFIED,
+                        description="Jurisdiction not found in lookup table.",
+                        inputs={"jurisdiction": jurisdiction, "claim_type": claim_type},
+                        output=f"UNSUPPORTED jurisdiction: '{jurisdiction}'. No limitation period available.",
+                        evidence_type=EVIDENCE_UNSUPPORTED,
+                    )
+                ],
             )
-        
+
         limits = self.LIMITATIONS[jurisdiction_upper]
-        
+
         # Fail-closed: exact claim type match only (no default fallback)
         if claim_type_lower not in limits:
             return StatuteResult(
@@ -321,27 +354,39 @@ class StatuteOfLimitationsGuard:
                 ),
                 jurisdiction_matched=True,
                 claim_type_matched=False,
+                verification_trace=[
+                    VerificationStep(
+                        step=STEP_RULE_IDENTIFIED,
+                        description="Jurisdiction matched but claim type not found in lookup table.",
+                        inputs={
+                            "jurisdiction": jurisdiction_upper,
+                            "claim_type": claim_type,
+                        },
+                        output=f"UNSUPPORTED claim type: '{claim_type}' for '{jurisdiction}'.",
+                        evidence_type=EVIDENCE_UNSUPPORTED,
+                    )
+                ],
             )
-        
+
         period_years = limits[claim_type_lower]
-        
+
         # Calculate expiration date
         expiration = incident + relativedelta(years=int(period_years))
         if period_years % 1 != 0:
             # Handle fractional years (e.g., 2.5 years)
             extra_months = int((period_years % 1) * 12)
             expiration = expiration + relativedelta(months=extra_months)
-        
+
         # Calculate days remaining
         days_remaining = (expiration - filing).days
         within_period = days_remaining >= 0
-        
+
         # Verify against LLM claim if provided
         if claimed_within_period is not None:
-            verified = (claimed_within_period == within_period)
+            verified = claimed_within_period == within_period
         else:
             verified = within_period
-        
+
         if within_period:
             message = (
                 f"✅ WITHIN STATUTE: Claim can be filed. "
@@ -352,7 +397,50 @@ class StatuteOfLimitationsGuard:
                 f"❌ EXPIRED: Statute of limitations expired on {expiration.strftime('%Y-%m-%d')}. "
                 f"Filing date is {abs(days_remaining)} days past expiration."
             )
-        
+
+        trace = [
+            VerificationStep(
+                step=STEP_RULE_IDENTIFIED,
+                description="Matched jurisdiction and claim type to a known limitation period.",
+                inputs={
+                    "jurisdiction": jurisdiction_upper,
+                    "claim_type": claim_type_lower,
+                },
+                output=f"Limitation period: {period_years} years",
+                evidence_type=EVIDENCE_PARSED,
+            ),
+            VerificationStep(
+                step=STEP_FACT_DERIVED,
+                description="Computed expiration date from accrual date + limitation period.",
+                inputs={
+                    "accrual_date": str(incident),
+                    "limitation_period_years": period_years,
+                },
+                output=f"Expiration date: {expiration.strftime('%Y-%m-%d')}",
+                evidence_type=EVIDENCE_DETERMINISTIC,
+            ),
+            VerificationStep(
+                step=STEP_FACT_DERIVED,
+                description="Computed days remaining between filing date and expiration date.",
+                inputs={"filing_date": str(filing), "expiration_date": str(expiration)},
+                output=(
+                    f"{days_remaining} days remaining"
+                    if days_remaining >= 0
+                    else f"{abs(days_remaining)} days past expiration"
+                ),
+                evidence_type=EVIDENCE_DETERMINISTIC,
+            ),
+            VerificationStep(
+                step=STEP_CONCLUSION,
+                description="Determined whether the claim falls within the statute of limitations.",
+                inputs={
+                    "within_period": within_period,
+                    "days_remaining": days_remaining,
+                },
+                output="WITHIN STATUTE" if within_period else "EXPIRED",
+                evidence_type=EVIDENCE_DETERMINISTIC,
+            ),
+        ]
         return StatuteResult(
             verified=verified,
             claim_type=claim_type,
@@ -362,52 +450,46 @@ class StatuteOfLimitationsGuard:
             limitation_period_years=period_years,
             expiration_date=expiration,
             days_remaining=days_remaining,
-            message=message
+            message=message,
+            verification_trace=trace,
         )
-    
+
     def get_limitation_period(
-        self,
-        claim_type: str,
-        jurisdiction: str
+        self, claim_type: str, jurisdiction: str
     ) -> Optional[float]:
         """
         Get the limitation period for a claim type in a jurisdiction.
-        
+
         Args:
             claim_type: Type of claim
             jurisdiction: State or country
-            
+
         Returns:
             Limitation period in years, or None if jurisdiction/claim unknown
         """
         claim_type_lower = claim_type.lower().replace(" ", "_")
         jurisdiction_upper = jurisdiction.upper().strip()
-        
+
         if jurisdiction_upper not in self.LIMITATIONS:
             return None
-        
+
         limits = self.LIMITATIONS[jurisdiction_upper]
         if claim_type_lower not in limits:
             return None
-        
+
         return limits[claim_type_lower]
-    
+
     def compare_jurisdictions(
-        self,
-        claim_type: str,
-        jurisdictions: list
+        self, claim_type: str, jurisdictions: list
     ) -> Dict[str, Optional[float]]:
         """
         Compare limitation periods across jurisdictions.
-        
+
         Args:
             claim_type: Type of claim
             jurisdictions: List of jurisdictions to compare
-            
+
         Returns:
             Dict mapping jurisdiction to limitation period (None if unknown)
         """
-        return {
-            j: self.get_limitation_period(claim_type, j)
-            for j in jurisdictions
-        }
+        return {j: self.get_limitation_period(claim_type, j) for j in jurisdictions}

--- a/qwed_legal/models.py
+++ b/qwed_legal/models.py
@@ -1,0 +1,97 @@
+"""
+QWED-Legal shared verification models.
+
+VerificationStep is the atomic unit of a verification_trace — a structured,
+auditable record of every decision made during a guard's verification run.
+
+Key distinction:
+  - verification_trace is NOT a narrative explanation.
+  - Each step has an evidence_type that explicitly classifies HOW the output
+    was derived: DETERMINISTIC, PARSED, INFERRED, HEURISTIC, or UNSUPPORTED.
+  - A step with evidence_type=PARSED is NOT proof. It means "we read/matched
+    this from structure" — authority or correctness is not claimed.
+  - Only DETERMINISTIC steps represent actual mathematical/logical proof.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Dict
+
+# ── Step type constants ────────────────────────────────────────────────────────
+STEP_RULE_IDENTIFIED = "RULE_IDENTIFIED"
+"""A legal rule, lookup result, or scope boundary was identified."""
+
+STEP_FACT_DERIVED = "FACT_DERIVED"
+"""An intermediate fact was computed or derived from inputs."""
+
+STEP_AMBIGUITY_NOTED = "AMBIGUITY_NOTED"
+"""An ambiguity, gap, or partial-modeling limitation was detected."""
+
+STEP_CONCLUSION = "CONCLUSION"
+"""The final conclusion of this guard's verification run."""
+
+# ── Evidence type constants ────────────────────────────────────────────────────
+EVIDENCE_DETERMINISTIC = "DETERMINISTIC"
+"""
+Output is provable by math or formal logic with no ambiguity.
+Examples: Z3 SAT/UNSAT, date arithmetic, integer comparison.
+This is the only evidence type that constitutes actual proof.
+"""
+
+EVIDENCE_PARSED = "PARSED"
+"""
+Output was read or matched from structure (regex, lookup table, JSON field).
+NOT a proof — structure match does not verify authority or correctness.
+Example: statute lookup table match, regex reporter match.
+"""
+
+EVIDENCE_INFERRED = "INFERRED"
+"""
+Output was derived via pattern matching or keyword analysis.
+Not proven — an inference that may be wrong for edge cases.
+Example: keyword-overlap coherence check in IRACGuard.
+"""
+
+EVIDENCE_HEURISTIC = "HEURISTIC"
+"""
+Output was produced by an approximate or statistical method.
+Not deterministic — result may vary with input framing.
+Example: counterfactual comparison in FairnessGuard.
+"""
+
+EVIDENCE_UNSUPPORTED = "UNSUPPORTED"
+"""
+The guard cannot model this input at all.
+No conclusion can be drawn — fail-closed.
+Example: unknown jurisdiction, unrecognized claim type.
+"""
+
+
+@dataclass
+class VerificationStep:
+    """
+    A single auditable step in a guard's verification_trace.
+
+    Fields:
+        step           — step type constant (STEP_RULE_IDENTIFIED etc.)
+        description    — human-readable explanation of what happened at this step
+        inputs         — dict of facts/values used to reach this step's output
+        output         — the conclusion reached at this step
+        evidence_type  — how the output was derived (DETERMINISTIC/PARSED/etc.)
+
+    Invariant: evidence_type=DETERMINISTIC is the only type that constitutes
+    actual mathematical/logical proof. All other types must NOT be treated as
+    verification proof by downstream consumers.
+    """
+
+    step: str
+    description: str
+    inputs: Dict[str, Any]
+    output: str
+    evidence_type: str
+
+    def is_proven(self) -> bool:
+        """
+        True only for DETERMINISTIC steps.
+        Convenience helper — does not substitute for checking evidence_type.
+        """
+        return self.evidence_type == EVIDENCE_DETERMINISTIC

--- a/qwed_legal/models.py
+++ b/qwed_legal/models.py
@@ -95,3 +95,43 @@ class VerificationStep:
         Convenience helper — does not substitute for checking evidence_type.
         """
         return self.evidence_type == EVIDENCE_DETERMINISTIC
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Return a JSON-safe dict representation of this step for export/audit.
+
+        The ``is_proven`` flag is included explicitly so external consumers do
+        not have to re-derive proof semantics from ``evidence_type``. Input
+        values are coerced to JSON-safe primitives; any non-serializable value
+        is stringified rather than dropped (no silent loss).
+        """
+        return {
+            "step": self.step,
+            "description": self.description,
+            "inputs": _json_safe(self.inputs),
+            "output": self.output,
+            "evidence_type": self.evidence_type,
+            "is_proven": self.is_proven(),
+        }
+
+
+def _json_safe(value: Any) -> Any:
+    """Coerce a value into a JSON-serializable structure without losing data."""
+    if isinstance(value, dict):
+        return {str(k): _json_safe(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_json_safe(v) for v in value]
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    # Fail-safe: stringify anything not natively JSON-serializable.
+    return str(value)
+
+
+def trace_to_dict(trace: "list") -> "list":
+    """
+    Serialize a verification_trace (list of VerificationStep) to a list of dicts.
+
+    Accepts any iterable of VerificationStep instances and returns JSON-safe
+    dicts via :meth:`VerificationStep.to_dict`.
+    """
+    return [step.to_dict() for step in trace]

--- a/tests/test_fairness_guard.py
+++ b/tests/test_fairness_guard.py
@@ -1,5 +1,13 @@
 import pytest
-from qwed_legal.guards.fairness_guard import FairnessGuard
+from qwed_legal.guards.fairness_guard import (
+    FairnessGuard,
+    STATUS_UNVERIFIABLE_FAIRNESS,
+    STATUS_LLM_GENERATION_FAILED,
+    RISK_HEURISTIC_BIAS_SIGNAL,
+    RISK_LLM_GENERATION_FAILED,
+)
+from qwed_legal.models import EVIDENCE_DETERMINISTIC
+
 
 class MockLLMClient:
     def __init__(self, responses):
@@ -12,95 +20,114 @@ class MockLLMClient:
             raise KeyError(f"MockLLMClient received unexpected prompt: {prompt!r}")
         return self.responses[prompt]
 
-def test_fairness_guard_consistent():
-    # Setup mock LLM that returns the same decision regardless of prompt
+
+def test_fairness_guard_consistent_is_never_verified():
+    # Fail-closed: consistent outcome is NOT proof of fairness (issue #18).
     llm = MockLLMClient({
         "Should we approve the loan for John?": "APPROVED",
         "Should we approve the loan for Jane?": "APPROVED"
     })
-    
+
     guard = FairnessGuard(llm_client=llm)
     original_prompt = "Should we approve the loan for John?"
     original_decision = "APPROVED"
     swaps = {"John": "Jane", "he": "she", "his": "her"}
-    
-    result = guard.verify_decision_fairness(original_prompt, original_decision, swaps)
-    
-    assert result["verified"] is True
-    assert result["status"] == "FAIRNESS_VERIFIED"
-    assert llm.call_history == ["Should we approve the loan for Jane?"]
 
-def test_fairness_guard_inconsistent_bias_detected():
-    # Setup mock LLM that returns a DIFFERENT decision for the counterfactual
+    result = guard.verify_decision_fairness(original_prompt, original_decision, swaps)
+
+    assert result["verified"] is False
+    assert result["status"] == STATUS_UNVERIFIABLE_FAIRNESS
+    assert llm.call_history == ["Should we approve the loan for Jane?"]
+    # No trace step may claim deterministic proof of fairness.
+    assert all(
+        s.evidence_type != EVIDENCE_DETERMINISTIC
+        for s in result["verification_trace"]
+    )
+
+
+def test_fairness_guard_inconsistent_bias_signal():
     llm = MockLLMClient({
         "Should we approve the loan for John?": "APPROVED",
-        "Should we approve the loan for Jane?": "DENIED" # Bias detected!
+        "Should we approve the loan for Jane?": "DENIED"  # Bias signal!
     })
-    
+
     guard = FairnessGuard(llm_client=llm)
     original_prompt = "Should we approve the loan for John?"
     original_decision = "APPROVED"
     swaps = {"John": "Jane", "he": "she", "his": "her"}
-    
+
     result = guard.verify_decision_fairness(original_prompt, original_decision, swaps)
-    
+
     assert result["verified"] is False
-    assert result["risk"] == "JUDICIAL_BIAS_DETECTED"
+    assert result["risk"] == RISK_HEURISTIC_BIAS_SIGNAL
     assert "variance" in result
     assert result["variance"]["original"] == "APPROVED"
     assert result["variance"]["counterfactual"] == "DENIED"
+
 
 def test_fairness_guard_requires_llm_client():
     guard = FairnessGuard(llm_client=None)
     with pytest.raises(ValueError, match="LLM client must be provided"):
         guard.verify_decision_fairness("prompt", "decision", {"a": "b"})
 
+
+def test_fairness_guard_empty_swap_fails_closed():
+    llm = MockLLMClient({})
+    guard = FairnessGuard(llm_client=llm)
+    result = guard.verify_decision_fairness("prompt", "decision", {})
+    assert result["verified"] is False
+    assert result["status"] == STATUS_UNVERIFIABLE_FAIRNESS
+
+
 def test_fairness_guard_preserves_case_and_matches_insensitively():
     llm = MockLLMClient({
         "Should we approve the loan for Jane? She is a good candidate. Give it to HER.": "APPROVED"
     })
-    
+
     guard = FairnessGuard(llm_client=llm)
     original_prompt = "Should we approve the loan for John? He is a good candidate. Give it to HIM."
     original_decision = "APPROVED"
     swaps = {"John": "Jane", "he": "she", "him": "her"}
-    
+
     result = guard.verify_decision_fairness(original_prompt, original_decision, swaps)
-    
-    assert result["verified"] is True
+
+    # Still fail-closed even though outcomes were consistent.
+    assert result["verified"] is False
     assert llm.call_history == ["Should we approve the loan for Jane? She is a good candidate. Give it to HER."]
+
 
 def test_fairness_guard_bidirectional_swap_does_not_revert():
     """Bidirectional swap {"he": "she", "she": "he"} must not cancel itself out."""
     original_prompt = "she applied for the loan, but he did not"
-    
+
     # Expected counterfactual: "he applied for the loan, but she did not"
     llm = MockLLMClient({
         "he applied for the loan, but she did not": "APPROVED",
     })
-    
+
     guard = FairnessGuard(llm_client=llm)
     result = guard.verify_decision_fairness(
         original_prompt,
         original_decision="APPROVED",
         protected_attribute_swap={"he": "she", "she": "he"},
     )
-    
-    assert result["verified"] is True
+
+    assert result["verified"] is False
     assert llm.call_history == ["he applied for the loan, but she did not"]
 
+
 def test_fairness_guard_handles_none_from_llm():
-    # Setup mock LLM that returns None
     llm = MockLLMClient({
         "Should we approve the loan for Jane?": None
     })
-    
+
     guard = FairnessGuard(llm_client=llm)
     original_prompt = "Should we approve the loan for John?"
     original_decision = "APPROVED"
     swaps = {"John": "Jane"}
-    
+
     result = guard.verify_decision_fairness(original_prompt, original_decision, swaps)
-    
+
     assert result["verified"] is False
-    assert result["risk"] == "LLM_GENERATION_FAILED"
+    assert result["risk"] == RISK_LLM_GENERATION_FAILED
+    assert result["status"] == STATUS_LLM_GENERATION_FAILED

--- a/tests/test_fairness_guard.py
+++ b/tests/test_fairness_guard.py
@@ -79,6 +79,20 @@ def test_fairness_guard_empty_swap_fails_closed():
     assert result["status"] == STATUS_UNVERIFIABLE_FAIRNESS
 
 
+def test_fairness_guard_rejects_non_string_swap_value():
+    llm = MockLLMClient({})
+    guard = FairnessGuard(llm_client=llm)
+    with pytest.raises(ValueError, match="must be strings"):
+        guard.verify_decision_fairness("prompt", "decision", {"John": None})
+
+
+def test_fairness_guard_rejects_case_colliding_keys():
+    llm = MockLLMClient({})
+    guard = FairnessGuard(llm_client=llm)
+    with pytest.raises(ValueError, match="collide when"):
+        guard.verify_decision_fairness("prompt", "decision", {"he": "she", "He": "him"})
+
+
 def test_fairness_guard_preserves_case_and_matches_insensitively():
     llm = MockLLMClient({
         "Should we approve the loan for Jane? She is a good candidate. Give it to HER.": "APPROVED"

--- a/tests/test_trace_serialization.py
+++ b/tests/test_trace_serialization.py
@@ -1,0 +1,87 @@
+"""
+Phase-3 tests: verification_trace serialization (to_dict / trace_to_dict).
+"""
+
+import json
+import datetime
+
+from qwed_legal.models import (
+    VerificationStep,
+    trace_to_dict,
+    STEP_CONCLUSION,
+    EVIDENCE_DETERMINISTIC,
+    EVIDENCE_PARSED,
+)
+from qwed_legal.guards.statute_guard import StatuteOfLimitationsGuard
+
+
+def _step(**kwargs):
+    defaults = dict(
+        step=STEP_CONCLUSION,
+        description="desc",
+        inputs={"a": 1},
+        output="out",
+        evidence_type=EVIDENCE_DETERMINISTIC,
+    )
+    defaults.update(kwargs)
+    return VerificationStep(**defaults)
+
+
+class TestVerificationStepToDict:
+    def test_contains_all_fields(self):
+        d = _step().to_dict()
+        assert set(d.keys()) == {
+            "step",
+            "description",
+            "inputs",
+            "output",
+            "evidence_type",
+            "is_proven",
+        }
+
+    def test_is_proven_true_for_deterministic(self):
+        assert _step(evidence_type=EVIDENCE_DETERMINISTIC).to_dict()["is_proven"] is True
+
+    def test_is_proven_false_for_parsed(self):
+        assert _step(evidence_type=EVIDENCE_PARSED).to_dict()["is_proven"] is False
+
+    def test_json_serializable(self):
+        # Should not raise.
+        json.dumps(_step().to_dict())
+
+    def test_non_serializable_input_is_stringified(self):
+        d = _step(inputs={"date": datetime.date(2020, 1, 1)}).to_dict()
+        assert d["inputs"]["date"] == "2020-01-01"
+        json.dumps(d)  # still serializable
+
+    def test_nested_inputs_preserved(self):
+        d = _step(inputs={"x": {"y": [1, 2, 3]}}).to_dict()
+        assert d["inputs"]["x"]["y"] == [1, 2, 3]
+
+    def test_non_string_keys_coerced(self):
+        d = _step(inputs={1: "one"}).to_dict()
+        assert d["inputs"]["1"] == "one"
+        json.dumps(d)
+
+
+class TestTraceToDict:
+    def test_serializes_full_guard_trace(self):
+        result = StatuteOfLimitationsGuard().verify(
+            claim_type="breach_of_contract",
+            jurisdiction="California",
+            incident_date="2020-01-01",
+            filing_date="2023-01-01",
+        )
+        serialized = trace_to_dict(result.verification_trace)
+        assert isinstance(serialized, list)
+        assert all(isinstance(s, dict) for s in serialized)
+        # End-to-end: the whole trace must be JSON-serializable.
+        json.dumps(serialized)
+
+    def test_empty_trace(self):
+        assert trace_to_dict([]) == []
+
+    def test_preserves_order(self):
+        steps = [_step(output="first"), _step(output="second")]
+        serialized = trace_to_dict(steps)
+        assert [s["output"] for s in serialized] == ["first", "second"]

--- a/tests/test_verification_trace.py
+++ b/tests/test_verification_trace.py
@@ -1,4 +1,4 @@
-﻿"""
+"""
 tests/test_verification_trace.py
 
 Phase-1 regression tests for verification_trace on StatuteGuard and ContradictionGuard.

--- a/tests/test_verification_trace.py
+++ b/tests/test_verification_trace.py
@@ -106,6 +106,12 @@ class TestStatuteVerificationTrace:
     def test_unsupported_step_is_not_proven(self):
         assert _statute(jurisdiction="MARS").verification_trace[0].is_proven() is False
 
+    def test_claim_mismatch_last_step_not_statute_conclusion(self):
+        result = _statute(claimed_within_period=False)
+        assert result.verified is False
+        assert result.verification_trace[-1].output == "CLAIM INCORRECT"
+        assert result.verification_trace[-1].is_proven() is True
+
 
 class TestContradictionVerificationTrace:
     def test_trace_key_present_in_dict(self):
@@ -195,3 +201,18 @@ class TestContradictionVerificationTrace:
     def test_conclusion_is_last_step(self):
         r = _contra([_clause("Max liability capped at 5000", "LIABILITY", 5000)])
         assert r["verification_trace"][-1].step == STEP_CONCLUSION
+
+    def test_partial_coverage_conclusion_is_deterministic(self):
+        r = _contra(
+            [
+                _clause("Max liability capped at 5000", "LIABILITY", 5000),
+                _clause("Payment due in 30 days", "PAYMENT", 30),
+            ]
+        )
+        assert r["status"] == "partial_coverage"
+        assert r["verification_trace"][-1].evidence_type == EVIDENCE_DETERMINISTIC
+
+    def test_message_mentions_only_present_supported_categories(self):
+        r = _contra([_clause("Max liability capped at 5000", "LIABILITY", 5000)])
+        assert "LIABILITY clauses" in r["message"]
+        assert "DURATION and LIABILITY clauses" not in r["message"]

--- a/tests/test_verification_trace.py
+++ b/tests/test_verification_trace.py
@@ -335,6 +335,17 @@ class TestJurisdictionVerificationTrace:
         assert result.verification_trace[0].step == STEP_RULE_IDENTIFIED
         assert result.verification_trace[-1].step == STEP_CONCLUSION
 
+    def test_forum_selection_warning_is_not_verified(self):
+        # Below diversity-jurisdiction threshold -> warning -> must NOT verify.
+        result = JurisdictionGuard().verify_forum_selection(
+            "California", contract_value=50000
+        )
+        assert result.verified is False
+        assert any(
+            s.step == STEP_AMBIGUITY_NOTED for s in result.verification_trace
+        )
+        assert result.verification_trace[-1].output == "FORUM NOT VERIFIED"
+
     def test_choice_of_law_empty_parties_fail_closed(self):
         result = JurisdictionGuard().verify_choice_of_law(
             parties_countries=[],

--- a/tests/test_verification_trace.py
+++ b/tests/test_verification_trace.py
@@ -335,6 +335,15 @@ class TestJurisdictionVerificationTrace:
         assert result.verification_trace[0].step == STEP_RULE_IDENTIFIED
         assert result.verification_trace[-1].step == STEP_CONCLUSION
 
+    def test_choice_of_law_empty_parties_fail_closed(self):
+        result = JurisdictionGuard().verify_choice_of_law(
+            parties_countries=[],
+            governing_law="California",
+            forum="California",
+        )
+        assert result.verified is False
+        assert result.verification_trace[0].evidence_type == EVIDENCE_UNSUPPORTED
+
     def test_convention_all_members_deterministic(self):
         result = JurisdictionGuard().check_convention_applicability(
             ["US", "DE"], "CISG"

--- a/tests/test_verification_trace.py
+++ b/tests/test_verification_trace.py
@@ -358,6 +358,11 @@ class TestJurisdictionVerificationTrace:
             s.step == STEP_AMBIGUITY_NOTED for s in result.verification_trace
         )
 
+    def test_convention_empty_parties_fail_closed(self):
+        result = JurisdictionGuard().check_convention_applicability([], "CISG")
+        assert result.verified is False
+        assert result.verification_trace[0].evidence_type == EVIDENCE_UNSUPPORTED
+
 
 class TestClauseVerificationTrace:
     def test_heuristic_conclusion_not_proven(self):

--- a/tests/test_verification_trace.py
+++ b/tests/test_verification_trace.py
@@ -11,6 +11,7 @@ from qwed_legal.guards.liability_guard import LiabilityGuard
 from qwed_legal.guards.jurisdiction_guard import JurisdictionGuard
 from qwed_legal.guards.clause_guard import ClauseGuard
 from qwed_legal.guards.citation_guard import CitationGuard
+from qwed_legal.guards.irac_guard import IRACGuard
 from qwed_legal.models import (
     VerificationStep,
     STEP_RULE_IDENTIFIED,
@@ -365,3 +366,33 @@ class TestCitationVerificationTrace:
         result = CitationGuard().check_statute_citation("42 U.S.C. § 1983")
         assert result.format_valid is True
         assert result.verification_trace[0].evidence_type == EVIDENCE_PARSED
+
+
+class TestIRACVerificationTrace:
+    _VALID = (
+        "Issue: Whether the contract is enforceable.\n"
+        "Rule: A contract requires offer, acceptance, and consideration.\n"
+        "Application: Here, offer and acceptance and consideration are present.\n"
+        "Conclusion: The contract is enforceable.\n"
+    )
+
+    def test_structure_valid_reasoning_unsupported(self):
+        result = IRACGuard().verify(self._VALID)
+        assert result.structure_valid is True
+        trace = result.verification_trace
+        assert trace[0].evidence_type == EVIDENCE_INFERRED
+        # Reasoning correctness can never be proven structurally.
+        assert trace[-1].evidence_type == EVIDENCE_UNSUPPORTED
+        assert trace[-1].is_proven() is False
+
+    def test_missing_section_unsupported(self):
+        result = IRACGuard().verify("Issue: something\nRule: a rule")
+        assert result.structure_valid is False
+        assert result.verification_trace[-1].evidence_type == EVIDENCE_UNSUPPORTED
+
+    def test_no_step_is_deterministic(self):
+        result = IRACGuard().verify(self._VALID)
+        assert all(
+            s.evidence_type != EVIDENCE_DETERMINISTIC
+            for s in result.verification_trace
+        )

--- a/tests/test_verification_trace.py
+++ b/tests/test_verification_trace.py
@@ -253,6 +253,25 @@ class TestDeadlineVerificationTrace:
         assert result.verified is False
         assert result.verification_trace[0].evidence_type == EVIDENCE_UNSUPPORTED
 
+    def test_calendar_days_remain_deterministic(self):
+        result = self._verify(term="30 days")
+        assert result.verification_trace[-1].evidence_type == EVIDENCE_DETERMINISTIC
+
+    def test_business_days_with_invalid_calendar_fail_closed(self):
+        # Force an invalid holiday calendar; business-day result must not be proven.
+        guard = DeadlineGuard(country="ZZ_NOT_A_COUNTRY")
+        assert guard.holiday_calendar_valid is False
+        result = guard.verify("2026-01-15", "10 business days", "2026-01-29")
+        assert result.verified is False
+        assert result.verification_trace[-1].evidence_type == EVIDENCE_UNSUPPORTED
+        assert result.verification_trace[-1].is_proven() is False
+
+    def test_business_days_with_valid_calendar_deterministic(self):
+        guard = DeadlineGuard(country="US")
+        assert guard.holiday_calendar_valid is True
+        result = guard.verify("2026-01-15", "10 business days", "2026-01-29")
+        assert result.verification_trace[-1].evidence_type == EVIDENCE_DETERMINISTIC
+
 
 class TestLiabilityVerificationTrace:
     def test_cap_trace_deterministic(self):
@@ -305,6 +324,35 @@ class TestJurisdictionVerificationTrace:
             parties_countries=["US", "DE"],
             governing_law="California",
             forum="California",
+        )
+        assert any(
+            s.step == STEP_AMBIGUITY_NOTED for s in result.verification_trace
+        )
+
+    def test_forum_selection_has_trace(self):
+        result = JurisdictionGuard().verify_forum_selection("California")
+        assert len(result.verification_trace) >= 2
+        assert result.verification_trace[0].step == STEP_RULE_IDENTIFIED
+        assert result.verification_trace[-1].step == STEP_CONCLUSION
+
+    def test_convention_all_members_deterministic(self):
+        result = JurisdictionGuard().check_convention_applicability(
+            ["US", "DE"], "CISG"
+        )
+        assert result.verified is True
+        assert result.verification_trace[-1].evidence_type == EVIDENCE_DETERMINISTIC
+        assert result.verification_trace[-1].is_proven() is True
+
+    def test_convention_unknown_unsupported(self):
+        result = JurisdictionGuard().check_convention_applicability(
+            ["US"], "MADE_UP_CONVENTION"
+        )
+        assert result.verified is False
+        assert result.verification_trace[0].evidence_type == EVIDENCE_UNSUPPORTED
+
+    def test_convention_partial_membership_has_trace(self):
+        result = JurisdictionGuard().check_convention_applicability(
+            ["US", "ZZ"], "CISG"
         )
         assert any(
             s.step == STEP_AMBIGUITY_NOTED for s in result.verification_trace

--- a/tests/test_verification_trace.py
+++ b/tests/test_verification_trace.py
@@ -6,6 +6,9 @@ Phase-1 regression tests for verification_trace on StatuteGuard and Contradictio
 
 from qwed_legal.guards.statute_guard import StatuteOfLimitationsGuard
 from qwed_legal.guards.contradiction_guard import ContradictionGuard, Clause
+from qwed_legal.guards.deadline_guard import DeadlineGuard
+from qwed_legal.guards.liability_guard import LiabilityGuard
+from qwed_legal.guards.jurisdiction_guard import JurisdictionGuard
 from qwed_legal.models import (
     VerificationStep,
     STEP_RULE_IDENTIFIED,
@@ -14,6 +17,7 @@ from qwed_legal.models import (
     STEP_CONCLUSION,
     EVIDENCE_DETERMINISTIC,
     EVIDENCE_PARSED,
+    EVIDENCE_INFERRED,
     EVIDENCE_UNSUPPORTED,
 )
 
@@ -216,3 +220,89 @@ class TestContradictionVerificationTrace:
         r = _contra([_clause("Max liability capped at 5000", "LIABILITY", 5000)])
         assert "LIABILITY clauses" in r["message"]
         assert "DURATION and LIABILITY clauses" not in r["message"]
+
+
+class TestDeadlineVerificationTrace:
+    def _verify(self, **kwargs):
+        defaults = dict(
+            signing_date="2026-01-15",
+            term="30 days",
+            claimed_deadline="2026-02-14",
+        )
+        defaults.update(kwargs)
+        return DeadlineGuard().verify(**defaults)
+
+    def test_trace_present_and_steps(self):
+        trace = self._verify().verification_trace
+        assert trace[0].step == STEP_RULE_IDENTIFIED
+        assert trace[0].evidence_type == EVIDENCE_PARSED
+        assert trace[-1].step == STEP_CONCLUSION
+        assert trace[-1].is_proven() is True
+
+    def test_ambiguous_term_unsupported(self):
+        result = self._verify(term="a reasonable period")
+        assert result.verified is False
+        assert len(result.verification_trace) == 1
+        assert result.verification_trace[0].evidence_type == EVIDENCE_UNSUPPORTED
+
+    def test_parse_error_unsupported(self):
+        result = self._verify(signing_date="not-a-date")
+        assert result.verified is False
+        assert result.verification_trace[0].evidence_type == EVIDENCE_UNSUPPORTED
+
+
+class TestLiabilityVerificationTrace:
+    def test_cap_trace_deterministic(self):
+        result = LiabilityGuard().verify_cap(5_000_000, 200, 10_000_000)
+        trace = result.verification_trace
+        assert result.verified is True
+        assert trace[-1].step == STEP_CONCLUSION
+        assert trace[-1].is_proven() is True
+        assert all(isinstance(s, VerificationStep) for s in trace)
+
+    def test_cap_mismatch_conclusion(self):
+        result = LiabilityGuard().verify_cap(5_000_000, 200, 15_000_000)
+        assert result.verified is False
+        assert result.verification_trace[-1].output == "CAP MISMATCH"
+
+    def test_tiered_trace(self):
+        result = LiabilityGuard().verify_tiered_liability(
+            [{"base": 1_000_000, "percentage": 100}], 1_000_000
+        )
+        assert result.verification_trace[-1].step == STEP_CONCLUSION
+
+    def test_indemnity_trace(self):
+        result = LiabilityGuard().verify_indemnity_limit(100_000, 3, 300_000)
+        assert result.verification_trace[-1].is_proven() is True
+
+
+class TestJurisdictionVerificationTrace:
+    def test_trace_present(self):
+        result = JurisdictionGuard().verify_choice_of_law(
+            parties_countries=["US"],
+            governing_law="California",
+            forum="California",
+        )
+        trace = result.verification_trace
+        assert trace[0].step == STEP_RULE_IDENTIFIED
+        assert trace[0].evidence_type == EVIDENCE_PARSED
+        assert trace[-1].step == STEP_CONCLUSION
+
+    def test_conclusion_is_inferred_not_proof(self):
+        result = JurisdictionGuard().verify_choice_of_law(
+            parties_countries=["US"],
+            governing_law="California",
+            forum="California",
+        )
+        assert result.verification_trace[-1].evidence_type == EVIDENCE_INFERRED
+        assert result.verification_trace[-1].is_proven() is False
+
+    def test_warnings_emit_ambiguity_step(self):
+        result = JurisdictionGuard().verify_choice_of_law(
+            parties_countries=["US", "DE"],
+            governing_law="California",
+            forum="California",
+        )
+        assert any(
+            s.step == STEP_AMBIGUITY_NOTED for s in result.verification_trace
+        )

--- a/tests/test_verification_trace.py
+++ b/tests/test_verification_trace.py
@@ -1,0 +1,197 @@
+﻿"""
+tests/test_verification_trace.py
+
+Phase-1 regression tests for verification_trace on StatuteGuard and ContradictionGuard.
+"""
+
+from qwed_legal.guards.statute_guard import StatuteOfLimitationsGuard
+from qwed_legal.guards.contradiction_guard import ContradictionGuard, Clause
+from qwed_legal.models import (
+    VerificationStep,
+    STEP_RULE_IDENTIFIED,
+    STEP_FACT_DERIVED,
+    STEP_AMBIGUITY_NOTED,
+    STEP_CONCLUSION,
+    EVIDENCE_DETERMINISTIC,
+    EVIDENCE_PARSED,
+    EVIDENCE_UNSUPPORTED,
+)
+
+
+def _statute(**kwargs):
+    g = StatuteOfLimitationsGuard()
+    defaults = dict(
+        claim_type="breach_of_contract",
+        jurisdiction="California",
+        incident_date="2020-01-01",
+        filing_date="2023-01-01",
+    )
+    defaults.update(kwargs)
+    return g.verify(**defaults)
+
+
+def _contra(clauses):
+    return ContradictionGuard().verify_consistency(clauses)
+
+
+def _clause(text, cat, val):
+    return Clause(text=text, category=cat, value=val)
+
+
+class TestStatuteVerificationTrace:
+    def test_happy_path_has_four_steps(self):
+        assert len(_statute().verification_trace) == 4
+
+    def test_step_types_in_order(self):
+        trace = _statute().verification_trace
+        assert trace[0].step == STEP_RULE_IDENTIFIED
+        assert trace[1].step == STEP_FACT_DERIVED
+        assert trace[2].step == STEP_FACT_DERIVED
+        assert trace[3].step == STEP_CONCLUSION
+
+    def test_evidence_types_happy_path(self):
+        trace = _statute().verification_trace
+        assert trace[0].evidence_type == EVIDENCE_PARSED
+        assert trace[1].evidence_type == EVIDENCE_DETERMINISTIC
+        assert trace[2].evidence_type == EVIDENCE_DETERMINISTIC
+        assert trace[3].evidence_type == EVIDENCE_DETERMINISTIC
+
+    def test_conclusion_is_last_step(self):
+        assert _statute().verification_trace[-1].step == STEP_CONCLUSION
+
+    def test_conclusion_is_proven(self):
+        assert _statute().verification_trace[-1].is_proven() is True
+
+    def test_conclusion_within_statute(self):
+        assert "WITHIN STATUTE" in _statute().verification_trace[-1].output
+
+    def test_expired_claim_conclusion_says_expired(self):
+        result = _statute(filing_date="2026-01-01")
+        assert "EXPIRED" in result.verification_trace[-1].output
+
+    def test_rule_identified_is_parsed_not_deterministic(self):
+        trace = _statute().verification_trace
+        assert trace[0].evidence_type == EVIDENCE_PARSED
+        assert trace[0].evidence_type != EVIDENCE_DETERMINISTIC
+
+    def test_unsupported_jurisdiction_single_unsupported_step(self):
+        result = _statute(jurisdiction="MARS")
+        assert len(result.verification_trace) == 1
+        assert result.verification_trace[0].evidence_type == EVIDENCE_UNSUPPORTED
+        assert result.verification_trace[0].step == STEP_RULE_IDENTIFIED
+
+    def test_unsupported_claim_type_single_unsupported_step(self):
+        result = _statute(claim_type="quantum_litigation")
+        assert len(result.verification_trace) == 1
+        assert result.verification_trace[0].evidence_type == EVIDENCE_UNSUPPORTED
+
+    def test_all_steps_are_verification_step_instances(self):
+        for step in _statute().verification_trace:
+            assert isinstance(step, VerificationStep)
+
+    def test_step_inputs_dict_present(self):
+        for step in _statute().verification_trace:
+            assert isinstance(step.inputs, dict)
+
+    def test_step_output_non_empty(self):
+        for step in _statute().verification_trace:
+            assert isinstance(step.output, str) and step.output.strip()
+
+    def test_verification_trace_is_list(self):
+        assert isinstance(_statute().verification_trace, list)
+
+    def test_parsed_step_is_not_proven(self):
+        assert _statute().verification_trace[0].is_proven() is False
+
+    def test_unsupported_step_is_not_proven(self):
+        assert _statute(jurisdiction="MARS").verification_trace[0].is_proven() is False
+
+
+class TestContradictionVerificationTrace:
+    def test_trace_key_present_in_dict(self):
+        assert "verification_trace" in _contra(
+            [_clause("Max liability 5000", "LIABILITY", 5000)]
+        )
+
+    def test_trace_is_list(self):
+        assert isinstance(
+            _contra([_clause("Max liability 5000", "LIABILITY", 5000)])[
+                "verification_trace"
+            ],
+            list,
+        )
+
+    def test_all_trace_entries_are_verification_steps(self):
+        r = _contra([_clause("Max liability 5000", "LIABILITY", 5000)])
+        for step in r["verification_trace"]:
+            assert isinstance(step, VerificationStep)
+
+    def test_contradiction_conclusion_deterministic(self):
+        r = _contra(
+            [
+                _clause("Max liability capped at 5000", "LIABILITY", 5000),
+                _clause("Minimum penalty is 10000", "LIABILITY", 10000),
+            ]
+        )
+        assert r["status"] == "contradiction"
+        conclusion = r["verification_trace"][-1]
+        assert conclusion.step == STEP_CONCLUSION
+        assert conclusion.evidence_type == EVIDENCE_DETERMINISTIC
+        assert conclusion.is_proven() is True
+
+    def test_consistent_clauses_conclusion_deterministic(self):
+        r = _contra(
+            [
+                _clause("Max liability capped at 10000", "LIABILITY", 10000),
+                _clause("Minimum penalty is 1000", "LIABILITY", 1000),
+            ]
+        )
+        assert r["status"] == "consistent"
+        conclusion = r["verification_trace"][-1]
+        assert conclusion.step == STEP_CONCLUSION
+        assert conclusion.evidence_type == EVIDENCE_DETERMINISTIC
+
+    def test_fact_derived_steps_per_clause(self):
+        clauses = [
+            _clause("Max liability capped at 5000", "LIABILITY", 5000),
+            _clause("Max liability capped at 8000", "LIABILITY", 8000),
+        ]
+        r = _contra(clauses)
+        fact_steps = [s for s in r["verification_trace"] if s.step == STEP_FACT_DERIVED]
+        assert len(fact_steps) == 2
+
+    def test_fact_derived_evidence_is_deterministic(self):
+        r = _contra([_clause("Max liability capped at 5000", "LIABILITY", 5000)])
+        fact_steps = [s for s in r["verification_trace"] if s.step == STEP_FACT_DERIVED]
+        assert all(s.evidence_type == EVIDENCE_DETERMINISTIC for s in fact_steps)
+
+    def test_rule_identified_is_parsed(self):
+        r = _contra([_clause("Max liability capped at 5000", "LIABILITY", 5000)])
+        assert r["verification_trace"][0].step == STEP_RULE_IDENTIFIED
+        assert r["verification_trace"][0].evidence_type == EVIDENCE_PARSED
+
+    def test_unsupported_category_has_unsupported_step(self):
+        r = _contra([_clause("Payment due in 30 days", "PAYMENT", 30)])
+        assert r["status"] == "unverifiable"
+        assert any(
+            s.evidence_type == EVIDENCE_UNSUPPORTED for s in r["verification_trace"]
+        )
+        assert not any(s.step == STEP_FACT_DERIVED for s in r["verification_trace"])
+
+    def test_empty_clauses_has_unsupported_step(self):
+        r = _contra([])
+        assert r["status"] == "unverifiable"
+        assert r["verification_trace"][0].evidence_type == EVIDENCE_UNSUPPORTED
+
+    def test_partial_coverage_has_ambiguity_noted(self):
+        r = _contra(
+            [
+                _clause("Max liability capped at 5000", "LIABILITY", 5000),
+                _clause("Payment due in 30 days", "PAYMENT", 30),
+            ]
+        )
+        assert any(s.step == STEP_AMBIGUITY_NOTED for s in r["verification_trace"])
+
+    def test_conclusion_is_last_step(self):
+        r = _contra([_clause("Max liability capped at 5000", "LIABILITY", 5000)])
+        assert r["verification_trace"][-1].step == STEP_CONCLUSION

--- a/tests/test_verification_trace.py
+++ b/tests/test_verification_trace.py
@@ -9,6 +9,8 @@ from qwed_legal.guards.contradiction_guard import ContradictionGuard, Clause
 from qwed_legal.guards.deadline_guard import DeadlineGuard
 from qwed_legal.guards.liability_guard import LiabilityGuard
 from qwed_legal.guards.jurisdiction_guard import JurisdictionGuard
+from qwed_legal.guards.clause_guard import ClauseGuard
+from qwed_legal.guards.citation_guard import CitationGuard
 from qwed_legal.models import (
     VerificationStep,
     STEP_RULE_IDENTIFIED,
@@ -306,3 +308,60 @@ class TestJurisdictionVerificationTrace:
         assert any(
             s.step == STEP_AMBIGUITY_NOTED for s in result.verification_trace
         )
+
+
+class TestClauseVerificationTrace:
+    def test_heuristic_conclusion_not_proven(self):
+        result = ClauseGuard().check_consistency(
+            [
+                "Seller may terminate with 30 days notice",
+                "Buyer may terminate with 60 days notice",
+            ]
+        )
+        trace = result.verification_trace
+        assert trace[-1].step == STEP_CONCLUSION
+        assert trace[-1].is_proven() is False
+        assert trace[-1].evidence_type == EVIDENCE_INFERRED
+
+    def test_limited_coverage_unsupported_step(self):
+        result = ClauseGuard().check_consistency(
+            ["The sky is blue", "Grass is green"]
+        )
+        assert result.status == "heuristic_pass_limited"
+        assert any(
+            s.evidence_type == EVIDENCE_UNSUPPORTED for s in result.verification_trace
+        )
+
+    def test_z3_path_is_deterministic(self):
+        from z3 import Bool
+
+        p = Bool("p")
+        result = ClauseGuard().verify_using_z3([p, p])
+        assert result.consistent is True
+        assert result.verification_trace[-1].evidence_type == EVIDENCE_DETERMINISTIC
+        assert result.verification_trace[-1].is_proven() is True
+
+    def test_z3_empty_unsupported(self):
+        result = ClauseGuard().verify_using_z3([])
+        assert result.verification_trace[0].evidence_type == EVIDENCE_UNSUPPORTED
+
+
+class TestCitationVerificationTrace:
+    def test_format_valid_authority_unsupported(self):
+        result = CitationGuard().verify("Brown v. Board, 347 U.S. 483")
+        assert result.format_valid is True
+        trace = result.verification_trace
+        assert trace[0].evidence_type == EVIDENCE_PARSED
+        # Authority can never be proven by format match.
+        assert trace[-1].evidence_type == EVIDENCE_UNSUPPORTED
+        assert trace[-1].is_proven() is False
+
+    def test_format_invalid_trace(self):
+        result = CitationGuard().verify("not a citation")
+        assert result.format_valid is False
+        assert result.verification_trace[-1].output == "FORMAT INVALID"
+
+    def test_statute_format_trace(self):
+        result = CitationGuard().check_statute_citation("42 U.S.C. § 1983")
+        assert result.format_valid is True
+        assert result.verification_trace[0].evidence_type == EVIDENCE_PARSED


### PR DESCRIPTION
## Overview

This PR hardens QWED Legal's verification boundary by moving guards away from opaque reasoning/heuristic overclaims and toward explicit, auditable, fail-closed verification semantics.

It introduces a shared verification trace model, rolls it out across all guards, hardens `FairnessGuard` against heuristic overclaim, and adds JSON-safe trace serialization.

Closes #21 · Closes #18

## Why

Previously, callers could receive success-like outputs without a clear verification lineage of:

- what rule was identified
- how facts were derived
- which steps are actually provable vs parsed/inferred/heuristic
- when the guard is unsupported and should fail closed

For legal-safety use cases, this is a trust-boundary risk. QWED should not imply legal proof where only heuristic or partial reasoning exists.

## What changed

### 1) Shared trace model (`qwed_legal/models.py`)

Added `VerificationStep` with:

- `step`: `RULE_IDENTIFIED` | `FACT_DERIVED` | `AMBIGUITY_NOTED` | `CONCLUSION`
- `description`, `inputs`, `output`
- `evidence_type`: `DETERMINISTIC` | `PARSED` | `INFERRED` | `HEURISTIC` | `UNSUPPORTED`
- `is_proven()` returns `True` only for `DETERMINISTIC`

Explicit contract: parsed/inferred/heuristic steps are visible but never treated as proof.

Naming: field is `verification_trace` (not `reasoning_trace` / `proof_trace`) because it can include non-proof evidence types — avoids semantic overclaim.

### 2) Phase 1 — deterministic pilot

`StatuteOfLimitationsGuard` and `ContradictionGuard` emit `verification_trace`.
Deterministic conclusions where applicable; explicit `UNSUPPORTED` fail-closed for unsupported inputs.
Statute claim-comparison and Z3 SAT/UNSAT lineage are recorded.

### 3) Phase 2 — full rollout + fail-closed hardening

`verification_trace` added to all remaining guards, each with honest evidence typing:

- **`DeadlineGuard`** — deterministic date/business-day computation; fail-closed when the requested holiday calendar cannot be built (business-day result is not presented as proven).
- **`LiabilityGuard`** — deterministic exact-match caps (simple, tiered, indemnity).
- **`JurisdictionGuard`** — parsed classification + `AMBIGUITY_NOTED`; conclusions marked `INFERRED`; fail-closed on empty parties; forum warnings now fail verification.
- **`ClauseGuard`** — heuristic checks marked `INFERRED`/limited-coverage `UNSUPPORTED`; explicit Z3 path is `DETERMINISTIC`.
- **`CitationGuard`** — format match is `PARSED`; authority is always `UNSUPPORTED` (never proven).
- **`IRACGuard`** — structure is `INFERRED`; reasoning correctness is always `UNSUPPORTED`.
- **`FairnessGuard`** (#18 core fix) — now never returns `verified=True`. A consistent counterfactual outcome is `UNVERIFIABLE_FAIRNESS`; a differing outcome is a `HEURISTIC_BIAS_SIGNAL` for human review. Incomplete inputs (no client, empty swap, `None` generation), non-string swap values, and case-colliding keys all fail closed.

### 4) Phase 3 — trace serialization

- `VerificationStep.to_dict()` returns a JSON-safe dict including an explicit `is_proven` flag.
- `trace_to_dict(trace)` serializes a full `verification_trace` to a `json.dumps`-able list of dicts.
- Non-serializable input values are stringified (no silent loss). Exported from `qwed_legal`.

### 5) Docs

- README gains a **Verification trace (auditability)** section: `evidence_type` table, `is_proven()` semantics, and a `trace_to_dict` export example.
- `FairnessGuard` row updated to `HEURISTIC / FAIL-CLOSED`.

## Behavior examples

**`StatuteGuard` happy path:**

```
[RULE_IDENTIFIED] [PARSED]         matched limitation period
[FACT_DERIVED]    [DETERMINISTIC]  expiration date
[FACT_DERIVED]    [DETERMINISTIC]  days remaining
[CONCLUSION]      [DETERMINISTIC]  within/outside statute
```

**Unsupported / fail-closed path:**

```
emits an UNSUPPORTED trace step
does not present unsupported scenarios as verified/legal-safe
```

**`FairnessGuard` (#18):**

```
consistent outcome → verified=False, UNVERIFIABLE_FAIRNESS
differing outcome  → verified=False, HEURISTIC_BIAS_SIGNAL
never emits a DETERMINISTIC (proven) fairness conclusion
```

## Test coverage

Added/expanded focused tests for:

- step order and trace shape across all guards
- evidence taxonomy correctness and `is_proven()` strictness
- deterministic SAT/UNSAT and date-arithmetic paths
- ambiguity/partial-coverage handling
- unsupported/fail-closed outcomes (incl. empty parties, bad holiday calendar, malformed fairness input)
- `to_dict()` / `trace_to_dict()` JSON-safety and `is_proven` flag

All tests pass (286) and lint is clean.

## Safety and compatibility

- Additive trace fields; existing fields preserved.
- **Intentional breaking change:** `FairnessGuard.verify_decision_fairness` no longer returns `verified=True` (resolves the #18 trust-boundary overclaim). Callers relying on the old success contract must update.
- No claim that heuristic/parsed/inferred steps are legal proof.
- Stronger fail-closed posture at all guard trust boundaries (no silent degradation).

## Reviewer focus checklist

- [ ] `evidence_type` taxonomy is semantically correct per guard
- [ ] `is_proven()` strictness (`DETERMINISTIC` only) enforced everywhere
- [ ] unsupported / empty / malformed inputs fail closed with explicit trace
- [ ] `FairnessGuard` never reports proven fairness (#18)
- [ ] `to_dict()` / `trace_to_dict()` output is JSON-serializable and lossless
- [ ] no overclaiming language in outputs/docs