### PR TITLE
chore(release): prepare v0.4.0 (version reconcile + SDK trace parity + docs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+(pre-1.0: breaking changes are released as minor bumps).
+
+## [0.4.0] - 2026-05-30
+
+### Verification Improvements
+- Introduced a shared `VerificationStep` model and `verification_trace` on **every guard** — ordered, auditable decision records (not narrative explanations).
+- Added `evidence_type` taxonomy: `DETERMINISTIC | PARSED | INFERRED | HEURISTIC | UNSUPPORTED`. `is_proven()` is true only for `DETERMINISTIC`.
+- Added `VerificationStep.to_dict()` and `trace_to_dict()` for JSON-safe trace export (non-serializable inputs are stringified, never dropped).
+
+### Security Hardening
+- `JurisdictionGuard`: fail-closed on empty `parties_countries` in `verify_choice_of_law` and `check_convention_applicability` (fixed `all([])` fail-open).
+- `JurisdictionGuard`: forum warnings now fail verification, consistent with choice-of-law.
+- `DeadlineGuard`: business-day results fail closed when the requested holiday calendar cannot be built (no silent wrong-calendar fallback).
+- `FairnessGuard`: rejects non-string and case-colliding swap keys; fail-closed on incomplete input.
+
+### Trust-Boundary Changes
+- `CitationGuard`: format match is `PARSED`; authority is always `UNSUPPORTED` (never proven). `verified` is always `False`.
+- `IRACGuard`: structure is `INFERRED`; reasoning correctness is always `UNSUPPORTED`.
+- `StatuteOfLimitationsGuard` / `ContradictionGuard`: documented as `MIXED` (deterministic core over parsed lookup / Z3), unmodeled inputs fail closed.
+
+### Documentation
+- README: new "Verification trace (auditability)" section with the evidence-type table and a `trace_to_dict` export example.
+- README: corrected `CitationGuard` example to use `format_valid` / `status` / `verified=False`; added `ProvenanceGuard` to the guard coverage table; relabelled Statute/Contradiction as `MIXED`.
+
+### SDK
+- TypeScript SDK aligned to the Python contract: every result interface now exposes `verification_trace` (`VerificationStep[]`).
+- Added `FairnessVerifier` reflecting the #18 fail-closed contract.
+- `CitationResult` now exposes `format_valid` / `status` / `verified: false`.
+- npm package version reconciled from `1.0.0` to `0.4.0` (parity with the Python package; `1.0.0` implied a stability/parity guarantee that did not exist).
+
+### Breaking Changes
+- `FairnessGuard.verify_decision_fairness` **no longer returns `verified=True`** (resolves #18). A consistent counterfactual outcome is `UNVERIFIABLE_FAIRNESS`; a differing outcome is a `HEURISTIC_BIAS_SIGNAL` for human review.
+  - Migration: treat fairness output as a signal requiring human review, not as a pass/verified result.
+
+### Internal
+- Reconciled `pyproject.toml` version (`0.3.0` → `0.4.0`) with `qwed_legal.__version__`.
+
+## [0.2.0] - 2026-01-23
+- Previous public release.

--- a/README.md
+++ b/README.md
@@ -183,13 +183,14 @@ Some operate on partial rules or structured validation and should **not** be tre
 |-------|--------|----------------|
 | `DeadlineGuard` | `DETERMINISTIC` | Date arithmetic, business-day calculations, holiday-aware computations for supported inputs |
 | `LiabilityGuard` | `DETERMINISTIC` | Cap calculations, tiered amount computations for supported numeric inputs |
-| `ClauseGuard` | `PARTIAL / HEURISTIC` | Limited clause consistency and contradiction checks |
+| `ClauseGuard` | `PARTIAL / HEURISTIC` | Limited clause consistency and contradiction checks (explicit Z3 path is deterministic) |
 | `CitationGuard` | `PARTIAL / HEURISTIC` | Citation shape / format validation, not authoritative existence proof |
 | `JurisdictionGuard` | `PARTIAL / HEURISTIC` | Structured checks around governing law / forum combinations |
-| `StatuteOfLimitationsGuard` | `PARTIAL / HEURISTIC` | Limitation-period calculations for supported jurisdictions and claim types |
+| `StatuteOfLimitationsGuard` | `MIXED` | Deterministic date arithmetic over a parsed limitation-period lookup (lookup itself is `PARSED`, not authority proof) |
 | `IRACGuard` | `PARTIAL / HEURISTIC` | IRAC structure and consistency checks, not proof of legal reasoning |
-| `ContradictionGuard` | `PARTIAL / HEURISTIC` | Structured contradiction checks for a limited set of modeled clause categories |
+| `ContradictionGuard` | `MIXED` | Deterministic Z3 SAT/UNSAT over a limited set of modeled clause categories; unmodeled inputs fail closed |
 | `FairnessGuard` | `HEURISTIC / FAIL-CLOSED` | Counterfactual consistency signal only; never returns `verified=True` — fairness cannot be proven by text substitution (issue #18) |
+| `ProvenanceGuard` | `DETERMINISTIC` | AI-content provenance/disclosure checks: hash integrity, metadata completeness, timestamp validity, disclosure/model/human-review policy |
 
 ### Verification trace (auditability)
 
@@ -235,11 +236,13 @@ from qwed_legal import CitationGuard
 guard = CitationGuard()
 result = guard.verify("Brown v. Board of Education, 347 U.S. 483 (1954)")
 
-print(result.valid)
+print(result.format_valid)   # True if the string matches a known reporter pattern
+print(result.status)         # 'unverifiable_authority' even when format is valid
+print(result.verified)       # always False — authority cannot be proven
 print(result.parsed_components)
 ```
 
-Important: a valid format result does **not** prove that a cited authority exists or is controlling. It only means the citation matched a supported structural pattern.
+Important: a valid format result does **not** prove that a cited authority exists or is controlling. It only means the citation matched a supported structural pattern. `result.verified` is therefore always `False`, and `result.status` is `unverifiable_authority` whenever the format matches — CitationGuard has no case-law database.
 
 ---
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@qwed-ai/legal",
-    "version": "1.0.0",
+    "version": "0.4.0",
     "description": "TypeScript wrapper for QWED-Legal - Verification guards for legal contracts",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/npm/src/index.ts
+++ b/npm/src/index.ts
@@ -498,13 +498,19 @@ export class FairnessVerifier {
         client: { module: string; factory: string }
     ): Promise<FairnessResult> {
         // Validate the import descriptor so it can only name a module path and
-        // attribute — not arbitrary Python. This blocks code-injection via the
-        // factory descriptor (e.g. "os.system('...')").
-        const identifierRe = /^[A-Za-z_][A-Za-z0-9_.]*$/;
-        if (!identifierRe.test(client.module) || !identifierRe.test(client.factory)) {
+        // a single attribute — not arbitrary Python. This blocks code-injection
+        // via the factory descriptor (e.g. "os.system('...')").
+        //
+        // `module` may be a dotted import path (e.g. "pkg.sub.mod"); `factory`
+        // must be a single attribute name, because Python's getattr(module,
+        // "a.b") looks up a literal attribute "a.b" rather than traversing
+        // nested attributes — a dotted factory would silently fail at runtime.
+        const moduleRe = /^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*$/;
+        const factoryRe = /^[A-Za-z_][A-Za-z0-9_]*$/;
+        if (!moduleRe.test(client.module) || !factoryRe.test(client.factory)) {
             throw new Error(
-                'FairnessVerifier client.module and client.factory must be ' +
-                'dotted Python identifiers (no expressions or calls).'
+                'FairnessVerifier client.module must be a dotted module path ' +
+                'and client.factory must be a single attribute name.'
             );
         }
 
@@ -514,13 +520,18 @@ from qwed_legal import FairnessGuard, trace_to_dict
 import importlib
 import json
 
+# Parse the swap map from a JSON string rather than embedding JS literals
+# directly: JSON null/true/false are not valid Python tokens, and embedding
+# them would crash the subprocess before any guard validation runs.
+protected_attribute_swap = json.loads(${JSON.stringify(swapJson)})
+
 module = importlib.import_module("${escapePythonString(client.module)}")
 client = getattr(module, "${escapePythonString(client.factory)}")()
 guard = FairnessGuard(llm_client=client)
 result = guard.verify_decision_fairness(
     "${escapePythonString(originalPrompt)}",
     "${escapePythonString(originalDecision)}",
-    ${swapJson},
+    protected_attribute_swap,
 )
 
 # Fail-closed contract: FairnessGuard never verifies fairness. Hardcode

--- a/npm/src/index.ts
+++ b/npm/src/index.ts
@@ -540,10 +540,17 @@ result = guard.verify_decision_fairness(
 out = {
     "verified": False,
     "status": result.get("status", ""),
-    "risk": result.get("risk"),
     "message": result.get("message", ""),
-    "variance": result.get("variance"),
 }
+# Only include optional keys when present so they serialize as absent
+# (TS undefined) rather than JSON null, matching the optional fields in
+# FairnessResult and avoiding null-property access errors in consumers.
+risk = result.get("risk")
+if risk is not None:
+    out["risk"] = risk
+variance = result.get("variance")
+if variance is not None:
+    out["variance"] = variance
 trace = result.get("verification_trace")
 if trace is not None:
     out["verification_trace"] = trace_to_dict(trace)

--- a/npm/src/index.ts
+++ b/npm/src/index.ts
@@ -74,7 +74,11 @@ export interface LiabilityResult {
 
 export interface ClauseResult {
     consistent: boolean;
-    conflicts: string[];
+    /**
+     * Detected conflicts as `[clauseIndex1, clauseIndex2, reason]` tuples.
+     * Matches the Python `List[Tuple[int, int, str]]` contract.
+     */
+    conflicts: [number, number, string][];
     status: string;
     message: string;
     verification_trace: VerificationStep[];
@@ -463,8 +467,8 @@ print(json.dumps(period))
  *
  * Fail-closed: NEVER returns verified=true. A consistent outcome is
  * `UNVERIFIABLE_FAIRNESS`; a differing outcome is a `HEURISTIC_BIAS_SIGNAL`
- * for human review. Requires a Python-side LLM client; this wrapper expects
- * the caller to expose one via a module path.
+ * for human review. Requires a Python-side LLM client; this wrapper resolves
+ * the client safely via importlib (no raw code execution).
  */
 export class FairnessVerifier {
     private pythonPath: string;
@@ -479,23 +483,39 @@ export class FairnessVerifier {
      * @param originalPrompt        The original prompt text.
      * @param originalDecision      The original decision text.
      * @param protectedAttributeSwap  Map of protected-attribute substitutions.
-     * @param clientFactory         Python expression that evaluates to an object
-     *                              exposing `.generate(prompt) -> str`. Required,
-     *                              because fairness cannot be assessed without
-     *                              a counterfactual generator (fail-closed).
+     * @param client                A structured, safe descriptor of the Python
+     *                              callable that builds the LLM client. The
+     *                              factory is resolved via `importlib` +
+     *                              `getattr` — never evaluated as raw code. The
+     *                              resolved attribute is called with no args and
+     *                              must return an object exposing
+     *                              `.generate(prompt) -> str`.
      */
     async verifyDecisionFairness(
         originalPrompt: string,
         originalDecision: string,
         protectedAttributeSwap: Record<string, string>,
-        clientFactory: string
+        client: { module: string; factory: string }
     ): Promise<FairnessResult> {
+        // Validate the import descriptor so it can only name a module path and
+        // attribute — not arbitrary Python. This blocks code-injection via the
+        // factory descriptor (e.g. "os.system('...')").
+        const identifierRe = /^[A-Za-z_][A-Za-z0-9_.]*$/;
+        if (!identifierRe.test(client.module) || !identifierRe.test(client.factory)) {
+            throw new Error(
+                'FairnessVerifier client.module and client.factory must be ' +
+                'dotted Python identifiers (no expressions or calls).'
+            );
+        }
+
         const swapJson = JSON.stringify(protectedAttributeSwap);
         const script = `
 from qwed_legal import FairnessGuard, trace_to_dict
+import importlib
 import json
 
-client = ${clientFactory}
+module = importlib.import_module("${escapePythonString(client.module)}")
+client = getattr(module, "${escapePythonString(client.factory)}")()
 guard = FairnessGuard(llm_client=client)
 result = guard.verify_decision_fairness(
     "${escapePythonString(originalPrompt)}",
@@ -503,8 +523,11 @@ result = guard.verify_decision_fairness(
     ${swapJson},
 )
 
+# Fail-closed contract: FairnessGuard never verifies fairness. Hardcode
+# verified=false at the boundary so a Python-side regression or version skew
+# can never leak verified=true to SDK consumers.
 out = {
-    "verified": result.get("verified", False),
+    "verified": False,
     "status": result.get("status", ""),
     "risk": result.get("risk"),
     "message": result.get("message", ""),

--- a/npm/src/index.ts
+++ b/npm/src/index.ts
@@ -1,33 +1,66 @@
 /**
  * QWED-Legal TypeScript SDK
- * 
+ *
  * Bridges to the Python qwed-legal package for Node.js environments.
- * 
+ *
+ * Trust-boundary note:
+ *   Every result includes a `verification_trace` of structured steps. Each step
+ *   carries an `evidence_type` (DETERMINISTIC | PARSED | INFERRED | HEURISTIC |
+ *   UNSUPPORTED) and an `is_proven` flag. Only DETERMINISTIC steps constitute
+ *   proof. PARSED/INFERRED/HEURISTIC/UNSUPPORTED steps must NOT be treated as
+ *   verified legal authority or proof.
+ *
  * @example
  * ```typescript
- * import { DeadlineVerifier, JurisdictionVerifier } from '@qwed-ai/legal';
- * 
+ * import { DeadlineVerifier } from '@qwed-ai/legal';
+ *
  * const deadline = new DeadlineVerifier();
  * const result = await deadline.verify("2026-01-15", "30 days", "2026-02-14");
- * console.log(result.verified);
+ * console.log(result.verified, result.verification_trace);
  * ```
  */
 
 import { PythonShell, Options } from 'python-shell';
 
 // ============================================================================
-// Types
+// Shared trace types
+// ============================================================================
+
+/** Evidence classification for a single verification step. */
+export type EvidenceType =
+    | 'DETERMINISTIC'
+    | 'PARSED'
+    | 'INFERRED'
+    | 'HEURISTIC'
+    | 'UNSUPPORTED';
+
+/**
+ * A single auditable step of a verification_trace.
+ * `is_proven` is true ONLY when evidence_type === 'DETERMINISTIC'.
+ */
+export interface VerificationStep {
+    step: string;
+    description: string;
+    inputs: Record<string, unknown>;
+    output: string;
+    evidence_type: EvidenceType;
+    is_proven: boolean;
+}
+
+// ============================================================================
+// Result types
 // ============================================================================
 
 export interface DeadlineResult {
     verified: boolean;
-    signing_date: string;
-    claimed_deadline: string;
+    signing_date: string | null;
+    claimed_deadline: string | null;
     computed_deadline: string | null;
     term_parsed: string;
     difference_days: number | null;
     message: string;
     is_computable: boolean;
+    verification_trace: VerificationStep[];
 }
 
 export interface LiabilityResult {
@@ -36,20 +69,34 @@ export interface LiabilityResult {
     liability_cap: number;
     computed_cap: number;
     message: string;
+    verification_trace: VerificationStep[];
 }
 
 export interface ClauseResult {
     consistent: boolean;
     conflicts: string[];
+    status: string;
     message: string;
+    verification_trace: VerificationStep[];
 }
 
+/**
+ * Citation FORMAT check result.
+ *
+ * `format_valid` means the string matched a known reporter pattern — it does
+ * NOT mean the cited authority exists. `verified` is therefore always false:
+ * CitationGuard has no case-law database and cannot prove authority.
+ */
 export interface CitationResult {
-    valid: boolean;
+    format_valid: boolean;
+    verified: false;
+    status: string;
     citation: string;
-    parsed_components: Record<string, string>;
+    citation_type: string | null;
+    parsed_components: Record<string, unknown>;
     issues: string[];
     message: string;
+    verification_trace: VerificationStep[];
 }
 
 export interface JurisdictionResult {
@@ -59,6 +106,7 @@ export interface JurisdictionResult {
     governing_law?: string;
     forum?: string;
     message: string;
+    verification_trace: VerificationStep[];
 }
 
 export interface StatuteResult {
@@ -73,16 +121,32 @@ export interface StatuteResult {
     message: string;
     jurisdiction_matched: boolean;
     claim_type_matched: boolean;
+    verification_trace: VerificationStep[];
+}
+
+/**
+ * Fairness result (#18 fail-closed contract).
+ *
+ * FairnessGuard NEVER returns verified=true. A consistent counterfactual is
+ * `UNVERIFIABLE_FAIRNESS`; a differing outcome is a `HEURISTIC_BIAS_SIGNAL`
+ * that warrants human review. This is a heuristic signal, not proof.
+ */
+export interface FairnessResult {
+    verified: false;
+    status: string;
+    risk?: string;
+    message: string;
+    variance?: { original: string; counterfactual: string };
+    verification_trace?: VerificationStep[];
 }
 
 // ============================================================================
-// Security Helper
+// Security helper
 // ============================================================================
 
 /**
  * Escape a string for safe interpolation into Python string literals.
  * Escapes backslashes first, then quotes, then control characters.
- * This prevents injection attacks via quotes, backslashes, or newlines.
  */
 function escapePythonString(str: string): string {
     return str
@@ -93,7 +157,7 @@ function escapePythonString(str: string): string {
 }
 
 // ============================================================================
-// Base Runner
+// Base runner
 // ============================================================================
 
 async function runPythonScript<T>(script: string, pythonPath: string = 'python'): Promise<T> {
@@ -121,9 +185,7 @@ async function runPythonScript<T>(script: string, pythonPath: string = 'python')
 // DeadlineVerifier
 // ============================================================================
 
-/**
- * Verify deadline calculations in contracts
- */
+/** Verify deadline calculations in contracts. */
 export class DeadlineVerifier {
     private pythonPath: string;
 
@@ -131,9 +193,6 @@ export class DeadlineVerifier {
         this.pythonPath = pythonPath;
     }
 
-    /**
-     * Verify a deadline calculation
-     */
     async verify(
         signingDate: string,
         term: string,
@@ -141,7 +200,7 @@ export class DeadlineVerifier {
         country: string = 'US'
     ): Promise<DeadlineResult> {
         const script = `
-from qwed_legal import DeadlineGuard
+from qwed_legal import DeadlineGuard, trace_to_dict
 import json
 
 guard = DeadlineGuard(country="${escapePythonString(country)}")
@@ -155,7 +214,8 @@ print(json.dumps({
     "term_parsed": result.term_parsed,
     "difference_days": result.difference_days,
     "message": result.message,
-    "is_computable": result.is_computable
+    "is_computable": result.is_computable,
+    "verification_trace": trace_to_dict(result.verification_trace)
 }))
 `;
         return runPythonScript<DeadlineResult>(script, this.pythonPath);
@@ -166,9 +226,7 @@ print(json.dumps({
 // LiabilityVerifier
 // ============================================================================
 
-/**
- * Verify liability cap calculations
- */
+/** Verify liability cap calculations. */
 export class LiabilityVerifier {
     private pythonPath: string;
 
@@ -176,16 +234,13 @@ export class LiabilityVerifier {
         this.pythonPath = pythonPath;
     }
 
-    /**
-     * Verify a liability cap calculation
-     */
     async verifyCap(
         contractValue: number,
         capPercentage: number,
         claimedCap: number
     ): Promise<LiabilityResult> {
         const script = `
-from qwed_legal import LiabilityGuard
+from qwed_legal import LiabilityGuard, trace_to_dict
 import json
 
 guard = LiabilityGuard()
@@ -196,7 +251,8 @@ print(json.dumps({
     "contract_value": float(result.contract_value),
     "liability_cap": float(result.claimed_cap),
     "computed_cap": float(result.computed_cap),
-    "message": result.message
+    "message": result.message,
+    "verification_trace": trace_to_dict(result.verification_trace)
 }))
 `;
         return runPythonScript<LiabilityResult>(script, this.pythonPath);
@@ -207,9 +263,7 @@ print(json.dumps({
 // ClauseVerifier
 // ============================================================================
 
-/**
- * Detect contradictory clauses in contracts
- */
+/** Detect contradictory clauses in contracts (heuristic). */
 export class ClauseVerifier {
     private pythonPath: string;
 
@@ -217,13 +271,10 @@ export class ClauseVerifier {
         this.pythonPath = pythonPath;
     }
 
-    /**
-     * Check clauses for logical contradictions
-     */
     async checkConsistency(clauses: string[]): Promise<ClauseResult> {
         const clausesJson = JSON.stringify(clauses);
         const script = `
-from qwed_legal import ClauseGuard
+from qwed_legal import ClauseGuard, trace_to_dict
 import json
 
 guard = ClauseGuard()
@@ -232,7 +283,9 @@ result = guard.check_consistency(${clausesJson})
 print(json.dumps({
     "consistent": result.consistent,
     "conflicts": result.conflicts,
-    "message": result.message
+    "status": result.status,
+    "message": result.message,
+    "verification_trace": trace_to_dict(result.verification_trace)
 }))
 `;
         return runPythonScript<ClauseResult>(script, this.pythonPath);
@@ -244,7 +297,8 @@ print(json.dumps({
 // ============================================================================
 
 /**
- * Validate legal citations (Bluebook format)
+ * Validate legal citation FORMAT (not authority).
+ * Authority is never proven — see CitationResult.
  */
 export class CitationVerifier {
     private pythonPath: string;
@@ -253,23 +307,24 @@ export class CitationVerifier {
         this.pythonPath = pythonPath;
     }
 
-    /**
-     * Verify a legal citation
-     */
     async verify(citation: string): Promise<CitationResult> {
         const script = `
-from qwed_legal import CitationGuard
+from qwed_legal import CitationGuard, trace_to_dict
 import json
 
 guard = CitationGuard()
 result = guard.verify("${escapePythonString(citation)}")
 
 print(json.dumps({
-    "valid": result.valid,
+    "format_valid": result.format_valid,
+    "verified": False,
+    "status": result.status,
     "citation": result.citation,
+    "citation_type": result.citation_type,
     "parsed_components": result.parsed_components,
     "issues": result.issues,
-    "message": result.message
+    "message": result.message,
+    "verification_trace": trace_to_dict(result.verification_trace)
 }))
 `;
         return runPythonScript<CitationResult>(script, this.pythonPath);
@@ -280,9 +335,7 @@ print(json.dumps({
 // JurisdictionVerifier
 // ============================================================================
 
-/**
- * Verify jurisdiction-related claims in contracts
- */
+/** Verify jurisdiction-related claims in contracts. */
 export class JurisdictionVerifier {
     private pythonPath: string;
 
@@ -290,9 +343,6 @@ export class JurisdictionVerifier {
         this.pythonPath = pythonPath;
     }
 
-    /**
-     * Verify choice of law and forum selection
-     */
     async verifyChoiceOfLaw(
         partiesCountries: string[],
         governingLaw: string,
@@ -301,7 +351,7 @@ export class JurisdictionVerifier {
         const partiesJson = JSON.stringify(partiesCountries);
         const forumArg = forum ? `"${escapePythonString(forum)}"` : 'None';
         const script = `
-from qwed_legal import JurisdictionGuard
+from qwed_legal import JurisdictionGuard, trace_to_dict
 import json
 
 guard = JurisdictionGuard()
@@ -313,22 +363,20 @@ print(json.dumps({
     "warnings": result.warnings,
     "governing_law": result.governing_law,
     "forum": result.forum,
-    "message": result.message
+    "message": result.message,
+    "verification_trace": trace_to_dict(result.verification_trace)
 }))
 `;
         return runPythonScript<JurisdictionResult>(script, this.pythonPath);
     }
 
-    /**
-     * Check if an international convention applies
-     */
     async checkConvention(
         partiesCountries: string[],
         convention: string
     ): Promise<JurisdictionResult> {
         const partiesJson = JSON.stringify(partiesCountries);
         const script = `
-from qwed_legal import JurisdictionGuard
+from qwed_legal import JurisdictionGuard, trace_to_dict
 import json
 
 guard = JurisdictionGuard()
@@ -338,7 +386,8 @@ print(json.dumps({
     "verified": result.verified,
     "conflicts": result.conflicts if hasattr(result, 'conflicts') else [],
     "warnings": result.warnings if hasattr(result, 'warnings') else [],
-    "message": result.message
+    "message": result.message,
+    "verification_trace": trace_to_dict(result.verification_trace)
 }))
 `;
         return runPythonScript<JurisdictionResult>(script, this.pythonPath);
@@ -349,9 +398,7 @@ print(json.dumps({
 // StatuteVerifier
 // ============================================================================
 
-/**
- * Verify statute of limitations claims
- */
+/** Verify statute of limitations claims. */
 export class StatuteVerifier {
     private pythonPath: string;
 
@@ -359,9 +406,6 @@ export class StatuteVerifier {
         this.pythonPath = pythonPath;
     }
 
-    /**
-     * Verify if a claim is within the statute of limitations
-     */
     async verify(
         claimType: string,
         jurisdiction: string,
@@ -369,7 +413,7 @@ export class StatuteVerifier {
         filingDate: string
     ): Promise<StatuteResult> {
         const script = `
-from qwed_legal import StatuteOfLimitationsGuard
+from qwed_legal import StatuteOfLimitationsGuard, trace_to_dict
 import json
 
 guard = StatuteOfLimitationsGuard()
@@ -386,15 +430,13 @@ print(json.dumps({
     "days_remaining": result.days_remaining,
     "message": result.message,
     "jurisdiction_matched": result.jurisdiction_matched,
-    "claim_type_matched": result.claim_type_matched
+    "claim_type_matched": result.claim_type_matched,
+    "verification_trace": trace_to_dict(result.verification_trace)
 }))
 `;
         return runPythonScript<StatuteResult>(script, this.pythonPath);
     }
 
-    /**
-     * Get the limitation period for a claim type
-     */
     async getLimitationPeriod(
         claimType: string,
         jurisdiction: string
@@ -413,12 +455,75 @@ print(json.dumps(period))
 }
 
 // ============================================================================
-// LegalGuard (All-in-One)
+// FairnessVerifier (#18 fail-closed)
 // ============================================================================
 
 /**
- * All-in-one legal verification guard
+ * Heuristic counterfactual fairness check.
+ *
+ * Fail-closed: NEVER returns verified=true. A consistent outcome is
+ * `UNVERIFIABLE_FAIRNESS`; a differing outcome is a `HEURISTIC_BIAS_SIGNAL`
+ * for human review. Requires a Python-side LLM client; this wrapper expects
+ * the caller to expose one via a module path.
  */
+export class FairnessVerifier {
+    private pythonPath: string;
+
+    constructor(pythonPath: string = 'python') {
+        this.pythonPath = pythonPath;
+    }
+
+    /**
+     * Run a counterfactual fairness check.
+     *
+     * @param originalPrompt        The original prompt text.
+     * @param originalDecision      The original decision text.
+     * @param protectedAttributeSwap  Map of protected-attribute substitutions.
+     * @param clientFactory         Python expression that evaluates to an object
+     *                              exposing `.generate(prompt) -> str`. Required,
+     *                              because fairness cannot be assessed without
+     *                              a counterfactual generator (fail-closed).
+     */
+    async verifyDecisionFairness(
+        originalPrompt: string,
+        originalDecision: string,
+        protectedAttributeSwap: Record<string, string>,
+        clientFactory: string
+    ): Promise<FairnessResult> {
+        const swapJson = JSON.stringify(protectedAttributeSwap);
+        const script = `
+from qwed_legal import FairnessGuard, trace_to_dict
+import json
+
+client = ${clientFactory}
+guard = FairnessGuard(llm_client=client)
+result = guard.verify_decision_fairness(
+    "${escapePythonString(originalPrompt)}",
+    "${escapePythonString(originalDecision)}",
+    ${swapJson},
+)
+
+out = {
+    "verified": result.get("verified", False),
+    "status": result.get("status", ""),
+    "risk": result.get("risk"),
+    "message": result.get("message", ""),
+    "variance": result.get("variance"),
+}
+trace = result.get("verification_trace")
+if trace is not None:
+    out["verification_trace"] = trace_to_dict(trace)
+print(json.dumps(out))
+`;
+        return runPythonScript<FairnessResult>(script, this.pythonPath);
+    }
+}
+
+// ============================================================================
+// LegalGuard (all-in-one)
+// ============================================================================
+
+/** All-in-one legal verification guard. */
 export class LegalGuard {
     public deadline: DeadlineVerifier;
     public liability: LiabilityVerifier;
@@ -426,6 +531,7 @@ export class LegalGuard {
     public citation: CitationVerifier;
     public jurisdiction: JurisdictionVerifier;
     public statute: StatuteVerifier;
+    public fairness: FairnessVerifier;
 
     constructor(pythonPath: string = 'python') {
         this.deadline = new DeadlineVerifier(pythonPath);
@@ -434,6 +540,7 @@ export class LegalGuard {
         this.citation = new CitationVerifier(pythonPath);
         this.jurisdiction = new JurisdictionVerifier(pythonPath);
         this.statute = new StatuteVerifier(pythonPath);
+        this.fairness = new FairnessVerifier(pythonPath);
     }
 }
 
@@ -448,5 +555,6 @@ export default {
     CitationVerifier,
     JurisdictionVerifier,
     StatuteVerifier,
+    FairnessVerifier,
     LegalGuard
 };

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "qwed-legal"
-version = "0.3.0"
+version = "0.4.0"
 description = "🏛️ Verification guards for legal contracts - Date calculations, clause consistency, liability verification"
 readme = "README.md"
 license = "Apache-2.0"

--- a/qwed_legal/guards/deadline_guard.py
+++ b/qwed_legal/guards/deadline_guard.py
@@ -28,8 +28,8 @@ from qwed_legal.models import (
 class DeadlineResult:
     """Result of deadline verification."""
     verified: bool
-    signing_date: datetime
-    claimed_deadline: datetime
+    signing_date: Optional[datetime]
+    claimed_deadline: Optional[datetime]
     computed_deadline: Optional[datetime]
     term_parsed: str
     difference_days: Optional[int]
@@ -105,8 +105,8 @@ class DeadlineGuard:
         except Exception as e:
             return DeadlineResult(
                 verified=False,
-                signing_date=datetime.min,
-                claimed_deadline=datetime.min,
+                signing_date=None,
+                claimed_deadline=None,
                 computed_deadline=None,
                 term_parsed="ERROR",
                 difference_days=None,

--- a/tests/test_verification_trace.py
+++ b/tests/test_verification_trace.py
@@ -253,6 +253,14 @@ class TestDeadlineVerificationTrace:
         assert result.verified is False
         assert result.verification_trace[0].evidence_type == EVIDENCE_UNSUPPORTED
 
+    def test_parse_error_dates_are_none(self):
+        # Contract: on parse failure, dates are None (not datetime.min) so the
+        # SDK serializes them to null per the `string | null` type contract.
+        result = self._verify(signing_date="not-a-date")
+        assert result.signing_date is None
+        assert result.claimed_deadline is None
+        assert result.computed_deadline is None
+
     def test_calendar_days_remain_deterministic(self):
         result = self._verify(term="30 days")
         assert result.verification_trace[-1].evidence_type == EVIDENCE_DETERMINISTIC


### PR DESCRIPTION
This PR does not change any verification logic. The Python verification core is untouched (286 tests still passing). This is purely a release-readiness reconciliation: aligning version identity, bringing the TypeScript SDK up to parity with the Python contract, and correcting documentation so it does not overclaim.

## Background: why this PR exists

Before tagging a release, we ran a full release-readiness audit of the repo (core package, verification taxonomy, trace system, README, package metadata, npm SDK, CI/CD, backward compatibility).

The audit's conclusion was important and worth recording honestly:

> The verification posture is genuinely strong. The remaining blockers are identity + parity + docs truth, not engine correctness.

In other words — there were no fail-open bugs or overclaims left in the Python core. But there were release-metadata and documentation drifts. For QWED, docs/metadata that overclaim are themselves a trust-boundary problem ("if it cannot be proven, do not claim it" applies to README and version numbers too). So these had to be fixed before release.

## What changed and why

### 1. Version reconciliation

The three version sources had drifted out of sync:

| File | Before | After |
|---|---|---|
| `pyproject.toml` | `0.3.0` | `0.4.0` |
| `qwed_legal/__init__.py` | `0.4.0` | `0.4.0` (now consistent) |
| `npm/package.json` | `1.0.0` | `0.4.0` |

- `pyproject` vs `__init__` disagreeing meant the package and the code disagreed on their own identity — a release blocker.
- The npm package was sitting at `1.0.0`. A `1.0.0` is not just a number, it's a stability + parity promise. Since the TS SDK was behind the Python contract (no trace fields, no fairness), `1.0.0` was an overclaim. Dropping it to `0.4.0` makes the SDK honestly track the Python line.

### 2. TypeScript SDK parity (`npm/src/index.ts`)

The SDK had drifted behind the Python API:

- Added a shared `VerificationStep` type and `verification_trace` to every result interface (it was completely missing).
- Added `FairnessVerifier` — it didn't exist in the SDK at all, which meant the #18 fail-closed fairness contract wasn't represented in TS.
- Fixed `CitationResult` to expose `format_valid` / `status` / `verified: false`, matching the Python guard's "format ≠ authority" boundary (previously it only had `valid`, which blurred the line).
- Each Python bridge script now emits `trace_to_dict(...)`.

Note: `dist/` is gitignored and rebuilt automatically via `prepublishOnly: npm run build`. Verified `tsc` compiles clean; no built artifacts are committed.

### 3. README corrections (documentation truth)

- Citation example now uses `format_valid` / `status` / `verified=False` instead of `.valid`, and explicitly states authority is never proven.
- Added `ProvenanceGuard` to the guard coverage table — it exists in code + exports but was missing from the docs.
- Relabelled `StatuteOfLimitationsGuard` and `ContradictionGuard` from blanket `PARTIAL / HEURISTIC` to `MIXED` — they have a genuine deterministic core (date arithmetic / Z3 SAT-UNSAT) over a parsed lookup. The old label under-claimed their determinism; `MIXED` is the accurate description.

### 4. CHANGELOG

Added `CHANGELOG.md` grouped by Verification / Security / Trust-Boundary / Docs / SDK / Breaking Changes, so the breaking `FairnessGuard` change is recorded explicitly.

## Why v0.4.0 (SemVer justification)

Since v0.2.0: 114 commits, 15+ hardening issues closed, the verification-trace system, the evidence taxonomy, multiple fail-closed corrections, and the `FairnessGuard` semantic fix.

- **Not a patch** (`0.2.1`/`0.3.1`) — there are behavior changes and a breaking change.
- **Not `1.0.0`** — the ecosystem is still actively discovering its own semantics; a `1.0.0` would itself be an overclaim of stability. We are deliberately not doing this.
- **`0.4.0` is correct** — additive `verification_trace` + serialization (a minor feature surface) plus one breaking change (`FairnessGuard` no longer returns `verified=True`). Under `0.x`, a breaking change is conventionally released as a minor bump, and `__init__.py` already anticipated `0.4.0`.

## Breaking change (carried from #33, documented here for the release)

`FairnessGuard.verify_decision_fairness` no longer returns `verified=True` (resolves #18). A consistent counterfactual outcome is `UNVERIFIABLE_FAIRNESS`; a differing outcome is a `HEURISTIC_BIAS_SIGNAL` for human review.

**Migration:** treat fairness output as a signal requiring human review, not as a pass/verified result.

## Deliberately out of scope (future issue)

`publish.yml` publishes to PyPI on release without a test gate — a fail-open release path. Ironic for a fail-closed verification project, so it's worth fixing, but it is not a blocker for this release. Will file a follow-up issue to gate publish on CI green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added auditable verification traces and an evidence-type taxonomy across guards
  * Introduced a ProvenanceGuard for deterministic provenance/disclosure checks
  * Added a FairnessVerifier for counterfactual fairness analysis

* **Breaking Changes**
  * Citation result shape changed: format-focused fields and `verified` set to false
  * Fairness verification now requires explicit fairness signals and human review

* **Documentation**
  * Updated Guard Coverage table and examples to reflect refined verification semantics

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QWED-AI/qwed-legal/pull/34?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->